### PR TITLE
feat: Add `classFingerprint` field to Fingerprint

### DIFF
--- a/api/morphe-patcher.api
+++ b/api/morphe-patcher.api
@@ -17,15 +17,19 @@ public final class app/morphe/patcher/FieldAccessFilter : app/morphe/patcher/Opc
 }
 
 public class app/morphe/patcher/Fingerprint {
-	public fun <init> ()V
+	public fun <init> (Lapp/morphe/patcher/Fingerprint;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (Lapp/morphe/patcher/Fingerprint;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function2;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function2;)V
 	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun clearMatch ()V
 	public final fun getAccessFlags ()Ljava/lang/Integer;
 	public final fun getClassDef (Lapp/morphe/patcher/patch/BytecodePatchContext;)Lapp/morphe/patcher/util/proxy/mutableTypes/MutableClass;
 	public final fun getClassDefOrNull (Lapp/morphe/patcher/patch/BytecodePatchContext;)Lapp/morphe/patcher/util/proxy/mutableTypes/MutableClass;
+	public final fun getClassFingerprint ()Lapp/morphe/patcher/Fingerprint;
 	public final fun getCustom ()Lkotlin/jvm/functions/Function2;
 	public final fun getDefiningClass ()Ljava/lang/String;
 	public final fun getFilters ()Ljava/util/List;

--- a/docs/2_2_1_fingerprinting.md
+++ b/docs/2_2_1_fingerprinting.md
@@ -376,6 +376,23 @@ Instead, the fingerprint can be matched manually using various overloads of a fi
       val match = showAdsFingerprint.match(adsLoaderClassFingerprint.originalClassDef)
   }
   ```
+  
+  This can be declared as part of the fingerprint itself, using the `classFingerprint` field:
+- ```kt
+    val showAdFingerprint = Fingerprint(
+        // Find class using another fingerprint, such as a method that contains unique strings.
+        classFingerprint = Fingerprint(name = "toString", strings = listOf("classField=")),
+        returnType = "Z",
+        parameters = listOf("Ljava/lang/String;"),
+        filters = listOf(
+            methodCall(
+                name = "getValue",
+                returnType = "Z",
+            ),
+            opcode(Opcode.MOVE_RESULT, MatchAfterImmediately())
+        )
+    )
+  ```
 
 > [!TIP]
 > To see real-world examples of fingerprints,

--- a/src/main/kotlin/app/morphe/patcher/Fingerprint.kt
+++ b/src/main/kotlin/app/morphe/patcher/Fingerprint.kt
@@ -24,22 +24,8 @@ import com.android.tools.smali.dexlib2.iface.reference.StringReference
 import com.android.tools.smali.dexlib2.util.MethodUtil
 import java.lang.ref.WeakReference
 
-/**
- * A fingerprint for a method. A fingerprint is a partial description of a method,
- * used to uniquely match a method by its characteristics.
- *
- * See the patcher documentation for more detailed explanations and example fingerprinting.
- *
- * @param definingClass Defining class. Type declaration follow the semantics described in [StringComparisonType].
- * @param name Exact method name.
- * @param accessFlags The exact access flags using values of [AccessFlags].
- * @param returnType The return type. Type declaration follow the semantics described in [StringComparisonType].
- * @param parameters The parameters. Type declaration follow the semantics described in [StringComparisonType].
- * @param filters A list of filters to match, declared in the same order the instructions appear in the method.
- * @param strings A list of strings that appear anywhere in the method in any order. Compared using [String.contains].
- * @param custom A custom condition for this fingerprint.
- */
-open class Fingerprint(
+open class Fingerprint private constructor(
+    val classFingerprint: Fingerprint? = null,
     val definingClass: String? = null,
     val name: String? = null,
     accessFlags: List<AccessFlags>? = null,
@@ -49,6 +35,112 @@ open class Fingerprint(
     val strings: List<String>? = null,
     val custom: ((method: Method, classDef: ClassDef) -> Boolean)? = null,
 ) {
+    /**
+     * A fingerprint for a method. A fingerprint is a partial description of a method,
+     * used to uniquely match a method by its characteristics.
+     *
+     * See the patcher documentation for more detailed explanations and example fingerprinting.
+     *
+     * @param classFingerprint Fingerprint that finds the class this fingerprint resolves against.
+     * @param name Exact method name.
+     * @param accessFlags The exact access flags using values of [AccessFlags].
+     * @param returnType The return type. Type declaration follow the semantics described in [StringComparisonType].
+     * @param parameters The parameters. Type declaration follow the semantics described in [StringComparisonType].
+     * @param filters A list of filters to match, declared in the same order the instructions appear in the method.
+     * @param strings A list of strings that appear anywhere in the method in any order. Compared using [String.contains].
+     * @param custom A custom condition for this fingerprint.
+     */
+    constructor(
+        classFingerprint: Fingerprint? = null,
+        name: String? = null,
+        accessFlags: List<AccessFlags>? = null,
+        returnType: String? = null,
+        parameters: List<String>? = null,
+        filters: List<InstructionFilter>? = null,
+        strings: List<String>? = null,
+        custom: ((method: Method, classDef: ClassDef) -> Boolean)? = null,
+    ) : this(
+        classFingerprint,
+        null,
+        name,
+        accessFlags,
+        returnType,
+        parameters,
+        filters,
+        strings,
+        custom
+    )
+
+    /**
+     * A fingerprint for a method. A fingerprint is a partial description of a method,
+     * used to uniquely match a method by its characteristics.
+     *
+     * See the patcher documentation for more detailed explanations and example fingerprinting.
+     *
+     * @param name Exact method name.
+     * @param accessFlags The exact access flags using values of [AccessFlags].
+     * @param returnType The return type. Type declaration follow the semantics described in [StringComparisonType].
+     * @param parameters The parameters. Type declaration follow the semantics described in [StringComparisonType].
+     * @param filters A list of filters to match, declared in the same order the instructions appear in the method.
+     * @param strings A list of strings that appear anywhere in the method in any order. Compared using [String.contains].
+     * @param custom A custom condition for this fingerprint.
+     */
+    constructor(
+        name: String? = null,
+        accessFlags: List<AccessFlags>? = null,
+        returnType: String? = null,
+        parameters: List<String>? = null,
+        filters: List<InstructionFilter>? = null,
+        strings: List<String>? = null,
+        custom: ((method: Method, classDef: ClassDef) -> Boolean)? = null,
+    ) : this(
+        null,
+        null,
+        name,
+        accessFlags,
+        returnType,
+        parameters,
+        filters,
+        strings,
+        custom
+    )
+
+    /**
+     * A fingerprint for a method. A fingerprint is a partial description of a method,
+     * used to uniquely match a method by its characteristics.
+     *
+     * See the patcher documentation for more detailed explanations and example fingerprinting.
+     *
+     * @param definingClass Defining class. Type declaration follow the semantics described in [StringComparisonType].
+     * @param name Exact method name.
+     * @param accessFlags The exact access flags using values of [AccessFlags].
+     * @param returnType The return type. Type declaration follow the semantics described in [StringComparisonType].
+     * @param parameters The parameters. Type declaration follow the semantics described in [StringComparisonType].
+     * @param filters A list of filters to match, declared in the same order the instructions appear in the method.
+     * @param strings A list of strings that appear anywhere in the method in any order. Compared using [String.contains].
+     * @param custom A custom condition for this fingerprint.
+     */
+    constructor( // Required to disambiguate if defining class or class fingerprint is not specified.
+        definingClass: String? = null,
+        name: String? = null,
+        accessFlags: List<AccessFlags>? = null,
+        returnType: String? = null,
+        parameters: List<String>? = null,
+        filters: List<InstructionFilter>? = null,
+        strings: List<String>? = null,
+        custom: ((method: Method, classDef: ClassDef) -> Boolean)? = null,
+    ) : this(
+        null,
+        definingClass,
+        name,
+        accessFlags,
+        returnType,
+        parameters,
+        filters,
+        strings,
+        custom
+    )
+
     // @Deprecated("Here only for backwards compatibility") // TODO: Remove after next major version bump.
     constructor(
         accessFlags: List<AccessFlags>? = null,
@@ -58,6 +150,7 @@ open class Fingerprint(
         strings: List<String>? = null,
         custom: ((method: Method, classDef: ClassDef) -> Boolean)? = null,
     ) : this(
+        null,
         null,
         null,
         accessFlags,
@@ -93,10 +186,14 @@ open class Fingerprint(
 
     init {
         // Verify an empty fingerprint wasn't declared.
-        if (name == null && definingClass == null && accessFlags == null && returnType == null
+        if (definingClass == null  && name == null && accessFlags == null && returnType == null
             && parameters == null && filters == null && strings == null && custom == null
         ) {
             throw IllegalArgumentException("At least one field must be set")
+        }
+
+        if (definingClass != null && classFingerprint != null) {
+            throw IllegalArgumentException("Cannot specify both definingClass and classFingerprint")
         }
 
         fingerprintList.add(WeakReference(this))
@@ -121,6 +218,14 @@ open class Fingerprint(
     context(BytecodePatchContext)
     fun matchOrNull(): Match? {
         if (_matchOrNull != null) return _matchOrNull
+
+        // Must check first.
+        val classFingerprintLocal = classFingerprint
+        if (classFingerprint != null) {
+            val match = match(classFingerprintLocal.originalClassDef)
+            _matchOrNull = match
+            return match
+        }
 
         // Use string declarations to first check only the classes
         // that contain one or more fingerprint strings.
@@ -228,6 +333,28 @@ open class Fingerprint(
         return null
     }
 
+    context(BytecodePatchContext)
+    private fun checkClassFingerprintMatchesDefiningClass(classDef: String) {
+        val classFingerprintLocal = classFingerprint
+        if (classFingerprintLocal != null) {
+            val originalClassDef = classFingerprintLocal.originalClassDef.type
+            if (originalClassDef != classDef) {
+                throw IllegalArgumentException("Fingerprint class fingerprint: $classFingerprintLocal " +
+                        "resolves to a different class: $originalClassDef than the " +
+                        "match classDef parameter: $classDef")
+            }
+
+            val definingClassLocal = definingClass
+            if (definingClassLocal != null) {
+                if (!definingClassComparison.compare(definingClassLocal, originalClassDef)) {
+                    throw IllegalArgumentException("Fingerprint class fingerprint: $classFingerprintLocal " +
+                            "resolves to a different class: $originalClassDef than this fingerprint " +
+                            "definingClass: $definingClassLocal")
+                }
+            }
+        }
+    }
+
     /**
      * Match using a [ClassDef].
      *
@@ -239,6 +366,8 @@ open class Fingerprint(
     fun matchOrNull(
         classDef: ClassDef
     ): Match? {
+        checkClassFingerprintMatchesDefiningClass(classDef.type)
+
         if (_matchOrNull != null) return _matchOrNull
 
         for (method in classDef.methods) {
@@ -264,6 +393,8 @@ open class Fingerprint(
     fun matchOrNull(
         method: Method,
     ): Match? {
+        checkClassFingerprintMatchesDefiningClass(method.definingClass)
+
         if (_matchOrNull != null) return _matchOrNull
 
         return matchOrNull(method, classDefBy(method.definingClass))
@@ -863,6 +994,8 @@ class FingerprintBuilder() {
 
     internal fun build(): Fingerprint {
         return Fingerprint(
+            definingClass = null,
+            name = null,
             accessFlags = accessFlags,
             returnType = returnType,
             parameters = parameters,

--- a/src/test/kotlin/app/morphe/patcher/PatcherTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/PatcherTest.kt
@@ -171,7 +171,7 @@ internal object PatcherTest {
     fun `matches fingerprint`() {
         every { patcher.context.bytecodeContext.patchClasses } returns PatchClasses(
             setOf(ImmutableClassDef(
-                    "class",
+                    "Lclass1;",
                     0,
                     null,
                     null,
@@ -180,10 +180,41 @@ internal object PatcherTest {
                     null,
                     listOf(
                         ImmutableMethod(
-                            "class",
-                            "method",
+                            "Lclass1;",
+                            "method1",
                             emptyList(),
                             "Ljava/lang/String;",
+                            0,
+                            null,
+                            null,
+                            null,
+                        )
+                    )
+                ),
+                ImmutableClassDef(
+                    "Lclass2;",
+                    0,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    listOf(
+                        ImmutableMethod(
+                            "Lclass2;",
+                            "method2",
+                            emptyList(),
+                            "Ljava/lang/String;",
+                            0,
+                            null,
+                            null,
+                            null,
+                        ),
+                        ImmutableMethod(
+                            "Lclass2;",
+                            "method3",
+                            emptyList(),
+                            "Ljava/lang/Integer;",
                             0,
                             null,
                             null,
@@ -201,26 +232,81 @@ internal object PatcherTest {
         val fingerprint1 = Fingerprint(returnType = "Ljava/lang/String;")
         val fingerprint2 = Fingerprint(returnType = "String;")
         val fingerprint3 = Fingerprint(returnType = "/lang")
+        val fingerprint4 = Fingerprint(name = "method2")
+        val fingerprint5 = Fingerprint(classFingerprint = fingerprint4, returnType = "Ljava/lang/String;")
+        val fingerprint6 = Fingerprint(name = "method1")
+        val fingerprint7 = Fingerprint(definingClass = "Lclass2;", name = "method1")
+        val fingerprint8 = Fingerprint(definingClass = "Lclass2", name = "method1")
+
+        assertThrows<IllegalArgumentException>("Empty fingerprint") {
+            Fingerprint(classFingerprint = fingerprint1)
+        }
 
         val patches = setOf(
             bytecodePatch {
                 execute {
+                    val class1 = patchClasses.classMap.values.first().classDef
+                    println("class1: $class1")
+                    val class2 = patchClasses.classMap.values.last().classDef
+                    println("class2: $class2")
+
                     fingerprint1.match(patchClasses.classMap.values.first().classDef.methods.first())
                     fingerprint2.match(patchClasses.classMap.values.first().classDef)
                     fingerprint3.originalClassDef
+                    fingerprint4.match()
+                    fingerprint5.match()
+                    fingerprint6.match()
+                    fingerprint7.match()
+                    fingerprint8.match()
                 }
-            },
+            }
         )
 
         patches()
 
         with(patcher.context.bytecodeContext) {
+            println("fingerprint4.originalClassDef.type: ")
+            println(fingerprint4.originalClassDef.type)
+            assertEquals(fingerprint4.originalClassDef.type, "Lclass2;")
+            assertEquals(fingerprint5.originalClassDef.type, "Lclass2;")
+
             assertAll(
                 "Expected fingerprints to match.",
                 { assertNotNull(fingerprint1.originalClassDefOrNull) },
                 { assertNotNull(fingerprint2.originalClassDefOrNull) },
                 { assertNotNull(fingerprint3.originalClassDefOrNull) },
             )
+
+            println("fingerprint5.originalClassDef: ${fingerprint5.originalClassDef}")
+            assertAll(
+                "classFingerprint resolves",
+                {
+                    assertTrue{
+                        fingerprint4.originalClassDef.type == "Lclass2;"
+                    }
+                    assertEquals(
+                        fingerprint5.originalClassDef, fingerprint4.originalClassDef
+                    )
+                }
+            )
+
+            assertThrows<Exception>(
+                "Matching class that differs from classFingerprint"
+            ) {
+                fingerprint5.match(fingerprint6.originalClassDef)
+            }
+
+            assertThrows<Exception>(
+                "Matching method that differs from classFingerprint"
+            ) {
+                fingerprint7.match(fingerprint6.method)
+            }
+
+            assertThrows<Exception>(
+                "Matching method that differs from classFingerprint"
+            ) {
+                fingerprint8.match(fingerprint6.method)
+            }
         }
     }
 


### PR DESCRIPTION
Adds a `classFingerprint` field that functionally is identical to calling:

`Fingerprint1.match(fingerprint2.originalClassDef).method`

Where now a fingerprint can declare a second fingerprint that finds the class.