### PR TITLE
refactor: Remove multidexlib2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,7 +72,6 @@ dependencies {
     implementation(libs.kotlin.reflect)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.serialization.json)
-    implementation(libs.multidexlib2)
     implementation(libs.smali)
 
     testImplementation(libs.mockk)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,6 @@ kotlinx-coroutines-core = "1.10.2"
 kotlinx-serialization = "1.7.1"
 mockk = "1.14.6"
 # Tracking https://github.com/google/smali/issues/100.
-multidexlib2 = "b6365a84f4"
 smali = "b6365a84f4"
 
 [libraries]
@@ -27,7 +26,6 @@ kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-c
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
-multidexlib2 = { module = "app.morphe:multidexlib2", version.ref = "multidexlib2" }
 smali = { module = "com.github.iBotPeaches.smali:smali", version.ref = "smali" }
 
 [plugins]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,7 +3,6 @@ rootProject.name = "morphe-patcher"
 // Include Morphe forks of libraries as composite builds if they exist locally
 mapOf(
     "ARSCLib" to "com.github.MorpheApp:arsclib",
-    "multidexlib2" to "app.morphe:multidexlib",
 ).forEach { (libraryPath, libraryName) ->
     val libDir = file("../$libraryPath")
     if (libDir.exists()) {

--- a/src/main/kotlin/app/morphe/patcher/dex/DexReadWrite.kt
+++ b/src/main/kotlin/app/morphe/patcher/dex/DexReadWrite.kt
@@ -12,11 +12,20 @@ import com.android.tools.smali.dexlib2.iface.ClassDef
 import com.android.tools.smali.dexlib2.iface.DexFile
 import com.android.tools.smali.dexlib2.writer.io.FileDataStore
 import com.android.tools.smali.dexlib2.writer.pool.DexPool
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import java.io.BufferedInputStream
 import java.io.File
 import java.io.InputStream
 import java.util.logging.Logger
+import kotlin.math.max
+import kotlin.math.min
 
 internal object DexReadWrite {
+    private const val MIN_CLASSES_PER_SEGMENT = 1000
+
     /**
      * Reads a multidex file and returns a [DexFile] containing all classes from all dex files in the multidex file.
      * @param inputFile The multidex file to read.
@@ -33,13 +42,15 @@ internal object DexReadWrite {
             container.getEntry(entry)!!.dexFile
         }
 
+        val opcodes = dexFiles.maxByOrNull { it.opcodes.api }!!.opcodes
+
         return object : DexFile {
             override fun getClasses(): Set<ClassDef> {
                 return dexFiles.flatMap { it.classes }.toSet()
             }
 
             override fun getOpcodes(): Opcodes {
-                return dexFiles.first().opcodes
+                return opcodes
             }
         }
     }
@@ -53,57 +64,129 @@ internal object DexReadWrite {
     internal fun readDexStream(inputStream: InputStream): DexFile {
         // This doesn't handle ODEX/OAT files, but we don't need to handle those for our use case, so it's fine.
         // Normally DexFileFactory would take care of this, but it doesn't support reading from streams, so we have to do it ourselves.
-        return DexBackedDexFile.fromInputStream(null, inputStream);
+        return DexBackedDexFile.fromInputStream(null, BufferedInputStream(inputStream))
     }
 
     /**
-     * Writes a [DexFile] to a multidex file in the specified output directory. The dex file will be split into multiple dex files if it exceeds the dex file size limit.
+     * Writes a [DexFile] to the specified output directory.
+     * The dex file will be split into multiple dex files if it exceeds the dex size limit.
      * @param outputDir The directory to write the multidex file to.
      * @param dexFile The [DexFile] to write.
-     * @param maxThreads The maximum number of threads to use for writing the dex files. (Currently ignored.)
+     * @param maxThreads The maximum number of threads to use for writing the dex files.
      *
      * @return A list of [File]s representing the written dex files.
      */
     internal fun writeMultiDexFile(outputDir: File, dexFile: DexFile, maxThreads: Int = -1, logger: Logger? = null): List<File> {
-        require(!outputDir.exists() || outputDir.isDirectory) { "output path must be a directory: $outputDir" }
+        require(!outputDir.exists() || outputDir.isDirectory) { "Output path must be a directory: $outputDir" }
 
         if (outputDir.exists()) {
             outputDir.deleteRecursively()
         }
         outputDir.mkdirs()
 
-        // TODO: Handle multi threaded writing of dex files
+        val availableProcessors = Runtime.getRuntime().availableProcessors()
+        val actualMaxThreads = if (maxThreads < 1) {
+            min(availableProcessors, 6)
+        } else {
+            min(min(maxThreads, 6), availableProcessors)
+        }
 
-        val sortedClasses = ArrayDeque(dexFile.classes.sortedBy { it.type })
+        val sortedClasses = dexFile.classes.sortedBy { it.type }
 
+        val numSegments = max(1, min(actualMaxThreads, sortedClasses.size / MIN_CLASSES_PER_SEGMENT))
+
+        val segmentResults = if (numSegments == 1) {
+            listOf(processSegment(sortedClasses, dexFile.opcodes, outputDir, 0))
+        } else {
+            val segments = splitIntoSegments(sortedClasses, numSegments)
+
+            logger?.info("Processing ${sortedClasses.size} classes in parallel (${segments.size} threads)")
+
+            val dispatcher = Dispatchers.Default.limitedParallelism(numSegments)
+            runBlocking(dispatcher) {
+                segments.mapIndexed { segmentIndex, classes ->
+                    async {
+                        processSegment(classes, dexFile.opcodes, outputDir, segmentIndex)
+                    }
+                }.awaitAll()
+            }
+        }
+
+        // Rename temp files to final dex files
         val dexFiles = mutableListOf<File>()
-        var currentDexPool = DexPool(dexFile.opcodes)
+        for (tempFiles in segmentResults) {
+            for (tempFile in tempFiles) {
+                val fileName = if (dexFiles.isEmpty()) "classes.dex" else "classes${dexFiles.size + 1}.dex"
+                val finalFile = outputDir.resolve(fileName)
+                tempFile.renameTo(finalFile)
+                dexFiles.add(finalFile)
+            }
+        }
 
-        while (sortedClasses.isNotEmpty()) {
-            val classDef = sortedClasses.first()
+        logger?.info("Wrote ${dexFiles.size} dex files to $outputDir")
+        return dexFiles
+    }
+
+    /**
+     * Splits a list into [numSegments] contiguous segments of roughly equal size.
+     */
+    private fun <T> splitIntoSegments(list: List<T>, numSegments: Int): List<List<T>> {
+        if (numSegments <= 1) return listOf(list)
+
+        val segmentSize = list.size / numSegments
+        val remainder = list.size % numSegments
+        val segments = mutableListOf<List<T>>()
+        var offset = 0
+
+        for (i in 0 until numSegments) {
+            // Distribute the remainder across the first segments (one extra element each).
+            val size = segmentSize + if (i < remainder) 1 else 0
+            segments.add(list.subList(offset, offset + size))
+            offset += size
+        }
+
+        return segments
+    }
+
+    /**
+     * Processes a segment of classes: fills one or more [DexPool]s and writes each to a temp file.
+     * Returns the list of temp files in the order they were produced.
+     */
+    private fun processSegment(
+        classes: List<ClassDef>,
+        opcodes: Opcodes,
+        outputDir: File,
+        segmentIndex: Int,
+    ): List<File> {
+        val tempFiles = mutableListOf<File>()
+        var currentDexPool = DexPool(opcodes)
+        val classQueue = ArrayDeque(classes)
+
+        while (classQueue.isNotEmpty()) {
+            val classDef = classQueue.first()
 
             currentDexPool.mark()
             currentDexPool.internClass(classDef)
             if (currentDexPool.hasOverflowed()) {
                 currentDexPool.reset()
-                dexFiles.add(writeDexPool(currentDexPool, outputDir, dexFiles.size, logger))
-
-                currentDexPool = DexPool(dexFile.opcodes)
+                tempFiles.add(writeDexPoolToTemp(currentDexPool, outputDir, segmentIndex, tempFiles.size))
+                currentDexPool = DexPool(opcodes)
             } else {
-                sortedClasses.removeFirst()
+                classQueue.removeFirst()
             }
         }
 
-        dexFiles.add(writeDexPool(currentDexPool, outputDir, dexFiles.size, logger))
-        logger?.info("Wrote ${dexFiles.size} dex files to $outputDir")
-        return dexFiles
+        tempFiles.add(writeDexPoolToTemp(currentDexPool, outputDir, segmentIndex, tempFiles.size))
+        return tempFiles
     }
 
-    private fun writeDexPool(dexPool: DexPool, outputDir: File, dexNum: Int, logger: Logger?): File {
-        val fileName = if (dexNum == 0) { "classes.dex" } else { "classes${dexNum + 2}.dex" }
-        val file = outputDir.resolve(fileName)
-        logger?.info("Writing $fileName")
-        dexPool.writeTo(FileDataStore(file))
-        return file
+    /**
+     * Writes a [DexPool] to a temporary file within the output directory.
+     * The temp file is named using the segment and pool indices to avoid collisions.
+     */
+    private fun writeDexPoolToTemp(dexPool: DexPool, outputDir: File, segmentIndex: Int, poolIndex: Int): File {
+        val tempFile = outputDir.resolve(".tmp_seg${segmentIndex}_${poolIndex}.dex")
+        dexPool.writeTo(FileDataStore(tempFile))
+        return tempFile
     }
 }

--- a/src/main/kotlin/app/morphe/patcher/dex/DexReadWrite.kt
+++ b/src/main/kotlin/app/morphe/patcher/dex/DexReadWrite.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patcher
+ */
+
+package app.morphe.patcher.dex
+
+import com.android.tools.smali.dexlib2.DexFileFactory
+import com.android.tools.smali.dexlib2.Opcodes
+import com.android.tools.smali.dexlib2.dexbacked.DexBackedDexFile
+import com.android.tools.smali.dexlib2.iface.ClassDef
+import com.android.tools.smali.dexlib2.iface.DexFile
+import com.android.tools.smali.dexlib2.writer.io.FileDataStore
+import com.android.tools.smali.dexlib2.writer.pool.DexPool
+import java.io.File
+import java.io.InputStream
+import java.util.logging.Logger
+
+internal object DexReadWrite {
+    /**
+     * Reads a multidex file and returns a [DexFile] containing all classes from all dex files in the multidex file.
+     * @param inputFile The multidex file to read.
+     * @param logger An optional logger to log the loading process.
+     *
+     * @return A [DexFile] containing all classes from all dex files in the multidex file.
+     */
+    internal fun readMultidexFile(inputFile: File, logger: Logger? = null): DexFile {
+        require(inputFile.exists()) { "input file does not exist: $inputFile" }
+
+        val container = DexFileFactory.loadDexContainer(inputFile, null)
+        logger?.info("Loaded multidex file: $inputFile with ${container.dexEntryNames.size} dex files")
+        val dexFiles = container.dexEntryNames.map { entry ->
+            container.getEntry(entry)!!.dexFile
+        }
+
+        return object : DexFile {
+            override fun getClasses(): Set<ClassDef> {
+                return dexFiles.flatMap { it.classes }.toSet()
+            }
+
+            override fun getOpcodes(): Opcodes {
+                return dexFiles.first().opcodes
+            }
+        }
+    }
+
+    internal fun readDexStream(inputStream: InputStream): DexFile {
+        // This doesn't handle ODEX/OAT files, but we don't need to handle those for our use case, so it's fine.
+        // Normally DexFileFactory would take care of this, but it doesn't support reading from streams, so we have to do it ourselves.
+        return DexBackedDexFile.fromInputStream(null, inputStream);
+    }
+
+    /**
+     * Writes a [DexFile] to a multidex file in the specified output directory. The dex file will be split into multiple dex files if it exceeds the dex file size limit.
+     * @param outputDir The directory to write the multidex file to.
+     * @param dexFile The [DexFile] to write.
+     * @param maxThreads The maximum number of threads to use for writing the dex files. (Currently ignored.)
+     *
+     * @return A list of [File]s representing the written dex files.
+     */
+    internal fun writeMultiDexFile(outputDir: File, dexFile: DexFile, maxThreads: Int = -1, logger: Logger? = null): List<File> {
+        require(!outputDir.exists() || outputDir.isDirectory) { "output path must be a directory: $outputDir" }
+
+        if (outputDir.exists()) {
+            outputDir.deleteRecursively()
+        }
+        outputDir.mkdirs()
+
+        // TODO: Handle multi threaded writing of dex files
+
+        val sortedClasses = ArrayDeque(dexFile.classes.sortedBy { it.type })
+
+        val dexFiles = mutableListOf<File>()
+        var currentDexPool = DexPool(dexFile.opcodes)
+
+        while (sortedClasses.isNotEmpty()) {
+            val classDef = sortedClasses.first()
+
+            currentDexPool.mark()
+            currentDexPool.internClass(classDef)
+            if (currentDexPool.hasOverflowed()) {
+                currentDexPool.reset()
+                dexFiles.add(writeDexPool(currentDexPool, outputDir, dexFiles.size, logger))
+
+                currentDexPool = DexPool(dexFile.opcodes)
+            } else {
+                sortedClasses.removeFirst()
+            }
+        }
+
+        dexFiles.add(writeDexPool(currentDexPool, outputDir, dexFiles.size, logger))
+        logger?.info("Wrote ${dexFiles.size} dex files to $outputDir")
+        return dexFiles
+    }
+
+    private fun writeDexPool(dexPool: DexPool, outputDir: File, dexNum: Int, logger: Logger?): File {
+        val fileName = if (dexNum == 0) { "classes.dex" } else { "classes${dexNum + 2}.dex" }
+        val file = outputDir.resolve(fileName)
+        logger?.info("Writing $fileName")
+        dexPool.writeTo(FileDataStore(file))
+        return file
+    }
+}

--- a/src/main/kotlin/app/morphe/patcher/dex/DexReadWrite.kt
+++ b/src/main/kotlin/app/morphe/patcher/dex/DexReadWrite.kt
@@ -25,6 +25,7 @@ import kotlin.math.min
 
 internal object DexReadWrite {
     private const val MIN_CLASSES_PER_SEGMENT = 1000
+    private const val MAX_THREADS = 4
 
     /**
      * Reads a multidex file and returns a [DexFile] containing all classes from all dex files in the multidex file.
@@ -86,21 +87,21 @@ internal object DexReadWrite {
 
         val availableProcessors = Runtime.getRuntime().availableProcessors()
         val actualMaxThreads = if (maxThreads < 1) {
-            min(availableProcessors, 6)
+            min(availableProcessors, MAX_THREADS)
         } else {
-            min(min(maxThreads, 6), availableProcessors)
+            min(min(maxThreads, MAX_THREADS), availableProcessors)
         }
 
-        val sortedClasses = dexFile.classes.sortedBy { it.type }
+        val classesAsList = dexFile.classes.toList()
 
-        val numSegments = max(1, min(actualMaxThreads, sortedClasses.size / MIN_CLASSES_PER_SEGMENT))
+        val numSegments = max(1, min(actualMaxThreads, classesAsList.size / MIN_CLASSES_PER_SEGMENT))
 
         val segmentResults = if (numSegments == 1) {
-            listOf(processSegment(sortedClasses, dexFile.opcodes, outputDir, 0))
+            listOf(processSegment(classesAsList, dexFile.opcodes, outputDir, 0))
         } else {
-            val segments = splitIntoSegments(sortedClasses, numSegments)
+            val segments = splitIntoSegments(classesAsList, numSegments)
 
-            logger?.info("Processing ${sortedClasses.size} classes in parallel (${segments.size} threads)")
+            logger?.info("Processing ${classesAsList.size} classes in parallel (${segments.size} threads)")
 
             val dispatcher = Dispatchers.Default.limitedParallelism(numSegments)
             runBlocking(dispatcher) {

--- a/src/main/kotlin/app/morphe/patcher/dex/DexReadWrite.kt
+++ b/src/main/kotlin/app/morphe/patcher/dex/DexReadWrite.kt
@@ -97,6 +97,8 @@ internal object DexReadWrite {
         val numSegments = max(1, min(actualMaxThreads, classesAsList.size / MIN_CLASSES_PER_SEGMENT))
 
         val segmentResults = if (numSegments == 1) {
+            logger?.info("Processing ${classesAsList.size} classes (single threaded mode)")
+
             listOf(processSegment(classesAsList, dexFile.opcodes, outputDir, 0))
         } else {
             val segments = splitIntoSegments(classesAsList, numSegments)

--- a/src/main/kotlin/app/morphe/patcher/dex/DexReadWrite.kt
+++ b/src/main/kotlin/app/morphe/patcher/dex/DexReadWrite.kt
@@ -44,6 +44,12 @@ internal object DexReadWrite {
         }
     }
 
+    /**
+     * Reads a dex file from an [InputStream] and returns a [DexFile] containing all classes from the dex file.
+     * @param inputStream The [InputStream] to read the dex file from.
+     *
+     * @return A [DexFile] containing all classes from the dex file.
+     */
     internal fun readDexStream(inputStream: InputStream): DexFile {
         // This doesn't handle ODEX/OAT files, but we don't need to handle those for our use case, so it's fine.
         // Normally DexFileFactory would take care of this, but it doesn't support reading from streams, so we have to do it ourselves.

--- a/src/main/kotlin/app/morphe/patcher/patch/BytecodePatchContext.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/BytecodePatchContext.kt
@@ -8,11 +8,8 @@
 
 package app.morphe.patcher.patch
 
-import app.morphe.patcher.InternalApi
-import app.morphe.patcher.PackageMetadata
-import app.morphe.patcher.PatcherConfig
-import app.morphe.patcher.PatcherResult
-import app.morphe.patcher.StringComparisonType
+import app.morphe.patcher.*
+import app.morphe.patcher.dex.DexReadWrite
 import app.morphe.patcher.util.ClassMerger.merge
 import app.morphe.patcher.util.MethodNavigator
 import app.morphe.patcher.util.PatchClasses
@@ -20,12 +17,7 @@ import com.android.tools.smali.dexlib2.Opcodes
 import com.android.tools.smali.dexlib2.iface.ClassDef
 import com.android.tools.smali.dexlib2.iface.DexFile
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
-import lanchon.multidexlib2.BasicDexFileNamer
-import lanchon.multidexlib2.DexIO
-import lanchon.multidexlib2.MultiDexIO
-import lanchon.multidexlib2.RawDexIO
 import java.io.Closeable
-import java.io.FileFilter
 import java.util.logging.Logger
 
 /**
@@ -48,13 +40,7 @@ class BytecodePatchContext internal constructor(private val config: PatcherConfi
      * All classes for the target app and any extension classes.
      */
     internal val patchClasses = PatchClasses(
-        MultiDexIO.readDexFile(
-            true,
-            config.apkFile,
-            BasicDexFileNamer(),
-            null,
-            null,
-        ).also { opcodes = it.opcodes }.classes
+        DexReadWrite.readMultidexFile(config.apkFile).also { opcodes = it.opcodes }.classes
     )
 
     /**
@@ -65,7 +51,7 @@ class BytecodePatchContext internal constructor(private val config: PatcherConfi
      */
     internal fun mergeExtension(bytecodePatch: BytecodePatch) {
         bytecodePatch.extensionInputStream?.get()?.use { extensionStream ->
-            RawDexIO.readRawDexFile(extensionStream, 0, null).classes.forEach { classDef ->
+            DexReadWrite.readDexStream(extensionStream).classes.forEach { classDef ->
                 val existingClass = patchClasses.classByOrNull(classDef.type) ?: run {
                     logger.fine { "Adding class \"$classDef\"" }
 
@@ -227,11 +213,8 @@ class BytecodePatchContext internal constructor(private val config: PatcherConfi
                 it.deleteRecursively() // Make sure the directory is empty.
                 it.mkdirs()
             }.apply {
-                MultiDexIO.writeDexFile(
-                    true,
-                    -1,
+                DexReadWrite.writeMultiDexFile(
                     this,
-                    BasicDexFileNamer(),
                     object : DexFile {
                         override fun getClasses(): Set<ClassDef> {
                             val values = this@BytecodePatchContext.patchClasses.classMap.values
@@ -240,9 +223,10 @@ class BytecodePatchContext internal constructor(private val config: PatcherConfi
 
                         override fun getOpcodes() = this@BytecodePatchContext.opcodes
                     },
-                    DexIO.DEFAULT_MAX_DEX_POOL_SIZE,
-                ) { _, entryName, _ -> logger.info { "Compiled $entryName" } }
-            }.listFiles(FileFilter { it.isFile })!!.map {
+                    -1,
+                    logger
+                )
+            }.listFiles { it.isFile }!!.map {
                 PatcherResult.PatchedDexFile(it.name, it.inputStream())
             }.toSet()
 

--- a/src/main/kotlin/app/morphe/patcher/patch/Patch.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/Patch.kt
@@ -4,9 +4,8 @@ package app.morphe.patcher.patch
 
 import app.morphe.patcher.Patcher
 import app.morphe.patcher.PatcherContext
+import app.morphe.patcher.dex.DexReadWrite
 import dalvik.system.DexClassLoader
-import lanchon.multidexlib2.BasicDexFileNamer
-import lanchon.multidexlib2.MultiDexIO
 import java.io.File
 import java.io.InputStream
 import java.lang.reflect.Member
@@ -597,7 +596,8 @@ sealed class PatchLoader(
         PatchLoader(
             patchesFiles,
             { patchBundle ->
-                MultiDexIO.readDexFile(true, patchBundle, BasicDexFileNamer(), null, null).classes
+                DexReadWrite.readMultidexFile(patchBundle)
+                    .classes
                     .map { classDef ->
                         classDef.type.substring(1, classDef.length - 1)
                     }


### PR DESCRIPTION
multidexlib2 is not maintained anymore, and it also includes a bunch of stuff we don't really need for basic reading/writing of multiple dex files.

This doesn't have support for odex/oat files, but these should not be a problem because we will always be working on dex files.