### PR TITLE
feat: Fingerprint matchAll() functionality

### DIFF
--- a/api/morphe-patcher.api
+++ b/api/morphe-patcher.api
@@ -51,6 +51,10 @@ public class app/morphe/patcher/Fingerprint {
 	public final fun match (Lapp/morphe/patcher/patch/BytecodePatchContext;Lcom/android/tools/smali/dexlib2/iface/ClassDef;)Lapp/morphe/patcher/Match;
 	public final fun match (Lapp/morphe/patcher/patch/BytecodePatchContext;Lcom/android/tools/smali/dexlib2/iface/Method;)Lapp/morphe/patcher/Match;
 	public final fun match (Lapp/morphe/patcher/patch/BytecodePatchContext;Lcom/android/tools/smali/dexlib2/iface/Method;Lcom/android/tools/smali/dexlib2/iface/ClassDef;)Lapp/morphe/patcher/Match;
+	public final fun matchAll (Lapp/morphe/patcher/patch/BytecodePatchContext;)Ljava/util/List;
+	public final fun matchAll (Lapp/morphe/patcher/patch/BytecodePatchContext;Lcom/android/tools/smali/dexlib2/iface/ClassDef;)Ljava/util/List;
+	public final fun matchAllOrNull (Lapp/morphe/patcher/patch/BytecodePatchContext;)Ljava/util/List;
+	public final fun matchAllOrNull (Lapp/morphe/patcher/patch/BytecodePatchContext;Lcom/android/tools/smali/dexlib2/iface/ClassDef;)Ljava/util/List;
 	public final fun matchOrNull (Lapp/morphe/patcher/patch/BytecodePatchContext;)Lapp/morphe/patcher/Match;
 	public final fun matchOrNull (Lapp/morphe/patcher/patch/BytecodePatchContext;Lcom/android/tools/smali/dexlib2/iface/ClassDef;)Lapp/morphe/patcher/Match;
 	public final fun matchOrNull (Lapp/morphe/patcher/patch/BytecodePatchContext;Lcom/android/tools/smali/dexlib2/iface/Method;)Lapp/morphe/patcher/Match;
@@ -216,6 +220,7 @@ public final class app/morphe/patcher/Match {
 	public final fun getOriginalMethod ()Lcom/android/tools/smali/dexlib2/iface/Method;
 	public final fun getStringMatches ()Ljava/util/List;
 	public final fun getStringMatchesOrNull ()Ljava/util/List;
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class app/morphe/patcher/Match$InstructionMatch {
@@ -529,6 +534,7 @@ public final class app/morphe/patcher/patch/BytecodePatchContext : app/morphe/pa
 	public fun close ()V
 	public synthetic fun get ()Ljava/lang/Object;
 	public fun get ()Ljava/util/Set;
+	public final fun getAllClassesWithString (Ljava/lang/String;)Ljava/util/List;
 	public final fun getAllClassesWithStrings ()Ljava/util/List;
 	public final fun getPackageMetadata ()Lapp/morphe/patcher/PackageMetadata;
 	public final fun mutableClassDefBy (Lcom/android/tools/smali/dexlib2/iface/ClassDef;)Lapp/morphe/patcher/util/proxy/mutableTypes/MutableClass;

--- a/docs/2_2_1_fingerprinting.md
+++ b/docs/2_2_1_fingerprinting.md
@@ -335,6 +335,28 @@ and only then will effectively replace the `original` method or class definition
 > If only read-only access to the class or method is needed, the `originalClassDef` and
 > `originalMethod` properties should be used, to avoid making a mutable copy of the class or method.
 
+
+## Finding all methods a fingerprint matches
+
+Fingerprints support finding all methods that match. A common usage is to change all 
+const-string instructions to a different string literal. 
+
+```kt
+
+// Replace a specific bytecode string in all const-string instructions.
+val stringFilter = string("exact string literal")
+Fingerprint(
+    filters = listOf(stringFilter)
+).matchAllOrNull()?.forEach { match ->
+    match.method.apply { 
+        // See Morphe ByteCodeUtils for findInstructionIndicesReversedOrThrow()
+        findInstructionIndicesReversedOrThrow(stringFilter).forEach { index ->
+        val register = getInstruction<OneRegisterInstruction>(index).registerA
+        replaceInstruction(index, "const-string v$register, \"$toString\"") 
+    }
+}
+```
+
 ## 🏹 Manually matching fingerprints
 
 By default, a fingerprint is matched automatically against all classes when one of the

--- a/src/main/kotlin/app/morphe/patcher/Fingerprint.kt
+++ b/src/main/kotlin/app/morphe/patcher/Fingerprint.kt
@@ -229,42 +229,8 @@ open class Fingerprint private constructor(
 
         // Use string declarations to first check only the classes
         // that contain one or more fingerprint strings.
-        val stringEqualMatch = mutableListOf<String>()
-        var hasPartialMatchStrings = false
-
-        // Store local to avoid more than one field access.
-        val stringsLocal = strings
-        if (stringsLocal != null) {
-            // Old unordered string declarations.
-            // Can be either equal or partial matches.
-            stringEqualMatch.addAll(stringsLocal)
-            hasPartialMatchStrings = true
-        }
-
-        val filtersLocal = filters
-        if (filtersLocal != null) {
-            fun filterStringFilterInstances(list: List<InstructionFilter>) =
-                list.filterIsInstance<StringFilter>()
-
-            fun addStringFilterLiterals(list: List<StringFilter>) {
-                list.forEach { filter ->
-                    val stringValue = filter.stringValue
-
-                    if (filter.comparison == StringComparisonType.EQUALS) {
-                        stringEqualMatch.add(stringValue)
-                    } else {
-                        hasPartialMatchStrings = true
-                    }
-                }
-            }
-
-            addStringFilterLiterals(filterStringFilterInstances(filtersLocal))
-
-            // Use strings declared inside anyInstruction.
-            filtersLocal.filterIsInstance<AnyInstruction>().forEach { anyFilter ->
-                addStringFilterLiterals(filterStringFilterInstances(anyFilter.filters))
-            }
-        }
+        val filterStrings = mutableListOf<String>()
+        findFilterStrings(filterStrings)
 
         fun machAllClassMethods(value: PatchClasses.ClassDefWrapper): Match? {
             val classDef = value.classDef
@@ -303,9 +269,9 @@ open class Fingerprint private constructor(
             return null
         }
 
-        if (stringEqualMatch.isNotEmpty() || hasPartialMatchStrings) {
-            stringEqualMatch.forEach { string ->
-                patchClasses.getClassFromOpcodeStringLiteral(string)?.forEach { stringClass ->
+        if (filterStrings.isNotEmpty()) {
+            filterStrings.forEach { string ->
+                patchClasses.getClassesFromOpcodeStringLiteral(string)?.forEach { stringClass ->
                     val value = machAllClassMethods(stringClass)
                     if (value != null) {
                         return value
@@ -314,8 +280,8 @@ open class Fingerprint private constructor(
             }
 
             // Fingerprint has partial string matches. Check all classes with strings.
-            patchClasses.getAllClassesWithStrings().forEach { value ->
-                val value = machAllClassMethods(value)
+            patchClasses.getAllClassesWithStrings().forEach { stringClass ->
+                val value = machAllClassMethods(stringClass)
                 if (value != null) {
                     return value
                 }
@@ -454,7 +420,7 @@ open class Fingerprint private constructor(
 
         // Legacy string declarations.
         val stringsLocal = strings
-        val stringMatches: List<Match.StringMatch>? = if (stringsLocal == null) {
+        var stringMatches: List<Match.StringMatch>? = if (stringsLocal == null) {
             null
         } else {
             buildList {
@@ -553,6 +519,16 @@ open class Fingerprint private constructor(
             matchFilters() ?: return null
         }
 
+        // Sort legacy string match results to the same order declared in the fingerprint.
+        if (stringMatches != null) {
+            val map = stringMatches.groupBy { it.string }
+                .mapValues { it.value.toMutableList() }
+
+            stringMatches = strings!!.mapNotNull { key ->
+                map[key]?.removeFirstOrNull()
+            }
+        }
+
         _matchOrNull = Match(
             classDef,
             method,
@@ -561,6 +537,109 @@ open class Fingerprint private constructor(
         )
 
         return _matchOrNull
+    }
+
+    private fun findFilterStrings(stringEqualMatch: MutableList<String>): Boolean {
+        var hasPartialMatchStrings = false
+
+        if (strings != null) {
+            // Old unordered string declarations.
+            // Can be either equal or partial matches.
+            stringEqualMatch.addAll(strings)
+            hasPartialMatchStrings = true
+        }
+
+        if (filters != null) {
+            fun filterStringFilterInstances(list: List<InstructionFilter>) =
+                list.filterIsInstance<StringFilter>()
+
+            fun addStringFilterLiterals(list: List<StringFilter>) {
+                list.forEach { filter ->
+                    stringEqualMatch.add(filter.stringValue)
+
+                    if (filter.comparison != StringComparisonType.EQUALS) {
+                        hasPartialMatchStrings = true
+                    }
+                }
+            }
+
+            addStringFilterLiterals(filterStringFilterInstances(filters))
+
+            // Use strings declared inside anyInstruction.
+            filters.filterIsInstance<AnyInstruction>().forEach { anyFilter ->
+                addStringFilterLiterals(filterStringFilterInstances(anyFilter.filters))
+            }
+        }
+
+        return hasPartialMatchStrings
+    }
+
+    /**
+     * Matches all methods in the class, or returns NULL if none match.
+     */
+    context(BytecodePatchContext)
+    fun matchAllOrNull(classDef: ClassDef): List<Match>? {
+        val matches = mutableListOf<Match>()
+
+        for (method in classDef.methods) {
+            val match = matchOrNull(method, classDef)
+            if (match != null) {
+                matches += match
+                clearMatch()
+            }
+        }
+
+        return matches.ifEmpty { null }
+    }
+
+    /**
+     * Matches all methods in the target app, or returns NULL if none match.
+     */
+    context(BytecodePatchContext)
+    fun matchAllOrNull(): List<Match>? {
+        val matches = mutableListOf<Match>()
+
+        fun machAllClassMethods(value: PatchClasses.ClassDefWrapper) {
+            val classDef = value.classDef
+            classDef.methods.forEach { method ->
+                val match = matchOrNull(method, classDef)
+                if (match != null) {
+                    matches += match
+                    clearMatch()
+                }
+            }
+        }
+
+        // If using built-in filters and not using anyFilter, and contain String literals,
+        // then can speed up matching by only checking classes with matching strings.
+        if (filters?.all { BUNDLED_INSTRUCTION_FILTERS.contains(it::class)} == true) {
+            val filterStrings = mutableListOf<String>()
+            val hasPartialMatchStrings = findFilterStrings(filterStrings)
+
+            if (filterStrings.isNotEmpty()) {
+                if (hasPartialMatchStrings) {
+                    patchClasses.getAllClassesWithStrings().forEach { stringClass ->
+                        machAllClassMethods(stringClass)
+                    }
+                } else {
+                    filterStrings.forEach { string ->
+                        patchClasses.getClassesFromOpcodeStringLiteral(string)
+                            ?.forEach { stringClass ->
+                                machAllClassMethods(stringClass)
+                            }
+                    }
+                }
+
+                return matches.ifEmpty { null }
+            }
+        }
+
+        // Check all classes.
+        patchClasses.classMap.values.forEach { value ->
+            machAllClassMethods(value)
+        }
+
+        return matches.ifEmpty { null }
     }
 
     fun patchException() = PatchException("Failed to match the fingerprint: $this")
@@ -612,6 +691,27 @@ open class Fingerprint private constructor(
         method: Method,
         classDef: ClassDef,
     ) = matchOrNull(method, classDef) ?: throw patchException()
+
+    /**
+     * Matches all methods in the target app.
+     *
+     * @param classDef The class the method is a member of.
+     * @return All methods that match.
+     * @throws PatchException If the fingerprint failed to match.
+     */
+    context(BytecodePatchContext)
+    fun matchAll(
+        classDef: ClassDef,
+    ) = matchAllOrNull(classDef) ?: throw patchException()
+
+    /**
+     * Match all methods in the target app.
+     *
+     * @return All methods that match.
+     * @throws PatchException If the fingerprint failed to match.
+     */
+    context(BytecodePatchContext)
+    fun matchAll() = matchAllOrNull() ?: throw patchException()
 
     /**
      * The class the matching method is a member of, or null if this fingerprint did not match.
@@ -796,6 +896,8 @@ class Match internal constructor(
     /**
      * The matches for strings declared in [Fingerprint.strings].
      *
+     * Match results will be in the same order declared in the fingerprint string list.
+     *
      * **Note**: Strings declared as instruction filters are not included in these legacy match results.
      *
      * This property may be deprecated in the future.
@@ -819,6 +921,12 @@ class Match internal constructor(
      */
     // TODO: Possibly deprecate this in the future.
     class StringMatch internal constructor(val string: String, val index: Int)
+
+    override fun toString(): String {
+        return "Match(originalMethod=$originalMethod, " +
+                "instructionMatches=$_instructionMatches, " +
+                "stringMatches=$_stringMatches)"
+    }
 }
 
 /**

--- a/src/main/kotlin/app/morphe/patcher/Fingerprint.kt
+++ b/src/main/kotlin/app/morphe/patcher/Fingerprint.kt
@@ -575,7 +575,7 @@ open class Fingerprint private constructor(
     }
 
     /**
-     * Matches all methods in the class, or returns NULL if none match.
+     * Matches all methods in the class that match, or returns NULL if none match.
      */
     context(BytecodePatchContext)
     fun matchAllOrNull(classDef: ClassDef): List<Match>? {
@@ -593,7 +593,8 @@ open class Fingerprint private constructor(
     }
 
     /**
-     * Matches all methods in the target app, or returns NULL if none match.
+     * Matches all methods in the target app that match, or returns NULL if none match.
+     * Match method index will be the first match in the method.
      */
     context(BytecodePatchContext)
     fun matchAllOrNull(): List<Match>? {

--- a/src/main/kotlin/app/morphe/patcher/InstructionFilter.kt
+++ b/src/main/kotlin/app/morphe/patcher/InstructionFilter.kt
@@ -14,6 +14,7 @@ import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.iface.reference.StringReference
 import com.android.tools.smali.dexlib2.iface.reference.TypeReference
 import java.util.EnumSet
+import kotlin.reflect.KClass
 
 /**
  * Simple interface to control how much space is allowed between a previous
@@ -152,6 +153,23 @@ fun interface InstructionLocation {
 }
 
 
+/**
+ * All filters here except for [AnyInstruction].
+ * Used to speed up [Fingerprint.matchAll] fingerprints that contain strings.
+ * Custom instruction filters could do logical filtering and will interfere with
+ * faster string matchAll operations.
+ */
+internal var BUNDLED_INSTRUCTION_FILTERS = setOf<KClass<*>>(
+    OpcodeFilter::class,
+    OpcodesFilter::class,
+    LiteralFilter::class,
+    MethodCallFilter::class,
+    FieldAccessFilter::class,
+    StringFilter::class,
+    NewInstanceFilter::class,
+    InstanceOfFilter::class,
+    CheckCastFilter::class
+)
 
 /**
  * Matches method [Instruction] objects, similar to how [Fingerprint] matches entire methods.

--- a/src/main/kotlin/app/morphe/patcher/patch/BytecodePatchContext.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/BytecodePatchContext.kt
@@ -16,6 +16,7 @@ import app.morphe.patcher.StringComparisonType
 import app.morphe.patcher.util.ClassMerger.merge
 import app.morphe.patcher.util.MethodNavigator
 import app.morphe.patcher.util.PatchClasses
+import app.morphe.patcher.util.PatchClasses.ClassDefWrapper
 import com.android.tools.smali.dexlib2.Opcodes
 import com.android.tools.smali.dexlib2.iface.ClassDef
 import com.android.tools.smali.dexlib2.iface.DexFile
@@ -193,12 +194,16 @@ class BytecodePatchContext internal constructor(private val config: PatcherConfi
      * @return All classes that contain at least 1 string.
      */
     fun getAllClassesWithStrings(): List<ClassDef> {
-        val classes = patchClasses.getAllClassesWithStrings()
-        val result = ArrayList<ClassDef>(classes.size)
-        for (wrapper in classes) {
-            result.add(wrapper.classDef)
-        }
-        return result
+        return patchClasses.getAllClassesWithStrings().map { it.classDef }
+    }
+
+    /**
+     * @return All classes that contain the exact string.
+     */
+    fun getAllClassesWithString(stringLiteral: String): List<ClassDef> {
+        val classes = patchClasses.getClassesFromOpcodeStringLiteral(stringLiteral)
+            ?: return emptyList()
+        return classes.map { it.classDef }
     }
 
     /**

--- a/src/main/kotlin/app/morphe/patcher/util/PatchClasses.kt
+++ b/src/main/kotlin/app/morphe/patcher/util/PatchClasses.kt
@@ -112,7 +112,7 @@ internal class PatchClasses internal constructor(
         }
 
         // Default 0.75f load factor works well and a lower value does not improve patching time.
-        val map = HashMap<String, LinkedList<ClassDefWrapper>>()
+        val map = HashMap<String, MutableList<ClassDefWrapper>>()
         val classesWithStrings = mutableListOf<ClassDefWrapper>()
 
         classMap.values.forEach { wrapper ->
@@ -120,7 +120,7 @@ internal class PatchClasses internal constructor(
             if (methodStrings != null) {
                 methodStrings.forEach { stringLiteral ->
                     val list = map.getOrPut(stringLiteral) {
-                        LinkedList()
+                        ArrayList(1)
                     }
                     if (!list.contains(wrapper)) {
                         list += wrapper

--- a/src/main/kotlin/app/morphe/patcher/util/PatchClasses.kt
+++ b/src/main/kotlin/app/morphe/patcher/util/PatchClasses.kt
@@ -119,9 +119,12 @@ internal class PatchClasses internal constructor(
             val methodStrings = wrapper.classDef.findMethodStrings()
             if (methodStrings != null) {
                 methodStrings.forEach { stringLiteral ->
-                    map.getOrPut(stringLiteral) {
+                    val list = map.getOrPut(stringLiteral) {
                         LinkedList()
-                    }.add(wrapper)
+                    }
+                    if (!list.contains(wrapper)) {
+                        list += wrapper
+                    }
                 }
 
                 classesWithStrings += wrapper
@@ -133,7 +136,7 @@ internal class PatchClasses internal constructor(
         return map
     }
 
-    internal fun getClassFromOpcodeStringLiteral(stringLiteral: String): List<ClassDefWrapper>? {
+    internal fun getClassesFromOpcodeStringLiteral(stringLiteral: String): List<ClassDefWrapper>? {
         return getClassesByStringMap()[stringLiteral]
     }
 

--- a/src/test/kotlin/app/morphe/patcher/PatcherTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/PatcherTest.kt
@@ -8,6 +8,7 @@
 
 package app.morphe.patcher
 
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.patch.BytecodePatch
 import app.morphe.patcher.patch.Patch
 import app.morphe.patcher.patch.PatchException
@@ -15,7 +16,12 @@ import app.morphe.patcher.patch.PatchResult
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.resource.ResourceMode
 import app.morphe.patcher.util.PatchClasses
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod.Companion.toMutable
+import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.builder.MutableMethodImplementation
+import com.android.tools.smali.dexlib2.iface.Method
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction
 import com.android.tools.smali.dexlib2.immutable.ImmutableClassDef
 import com.android.tools.smali.dexlib2.immutable.ImmutableMethod
 import com.android.tools.smali.dexlib2.immutable.instruction.ImmutableInstruction21c
@@ -30,10 +36,12 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.assertAll
 import org.junit.jupiter.api.assertThrows
 import java.util.logging.Logger
+import kotlin.reflect.KClass
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 internal object PatcherTest {
@@ -309,6 +317,370 @@ internal object PatcherTest {
             }
         }
     }
+
+    @Test
+    fun `fingerprint matchAll`() {
+        val class1 = ImmutableClassDef(
+            "Lclass1;",
+            0,
+            null,
+            null,
+            null,
+            null,
+            null,
+            listOf(
+                ImmutableMethod(
+                    "Lclass1;",
+                    "method1",
+                    emptyList(),
+                    "Ljava/lang/String;",
+                    AccessFlags.PUBLIC.value,
+                    null,
+                    null,
+                    MutableMethodImplementation(1),
+                ).toMutable().apply {
+                    addInstructions(
+                        0,
+                        """
+                            const/4 v0, 0x0
+                            const-string v0, "string_example"
+                            return-void
+                        """
+                    )
+                }
+            )
+        )
+
+        every { patcher.context.bytecodeContext.patchClasses } returns PatchClasses(
+            setOf(
+                class1,
+                ImmutableClassDef(
+                    "Lclass2;",
+                    0,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    listOf(
+                        ImmutableMethod(
+                            "Lclass2;",
+                            "method2",
+                            emptyList(),
+                            "Ljava/lang/String;",
+                            AccessFlags.PUBLIC.value,
+                            null,
+                            null,
+                            MutableMethodImplementation(1),
+                        ).toMutable().apply {
+                            addInstructions(
+                                0,
+                                """
+                                    const/4 v0, 0x0
+                                    const-string v0, "string_example"
+                                    return-void
+                                """
+                            )
+                        }
+                    )
+                ),
+                ImmutableClassDef(
+                    "Lclass3;",
+                    0,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    listOf(
+                        ImmutableMethod(
+                            "Lclass3;",
+                            "method3",
+                            emptyList(),
+                            "Ljava/lang/String;",
+                            AccessFlags.PUBLIC.value,
+                            null,
+                            null,
+                            MutableMethodImplementation(1),
+                        ).toMutable().apply {
+                            addInstructions(
+                                0,
+                                """
+                                    const/4 v0, 0x0
+                                    const-string v0, "string_example_long"
+                                    return-void
+                                """
+                            )
+                        }
+                    )
+                ),
+                ImmutableClassDef(
+                    "Lclass4;",
+                    0,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    listOf(
+                        ImmutableMethod(
+                            "Lclass4;",
+                            "method4",
+                            emptyList(),
+                            "Ljava/lang/String;",
+                            AccessFlags.PUBLIC.value,
+                            null,
+                            null,
+                            MutableMethodImplementation(1),
+                        ).toMutable().apply {
+                            addInstructions(
+                                0,
+                                """
+                                    const/4 v0, 0x0
+                                    const-string v0, "other_string"
+                                    return-void
+                                """
+                            )
+                        }
+                    )
+                ),
+                ImmutableClassDef(
+                    "Lclass5;",
+                    0,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    listOf(
+                        ImmutableMethod(
+                            "Lclass5;",
+                            "method5",
+                            emptyList(),
+                            "Ljava/lang/String;",
+                            AccessFlags.PUBLIC.value,
+                            null,
+                            null,
+                            MutableMethodImplementation(1),
+                        ).toMutable().apply {
+                            addInstructions(
+                                0,
+                                """
+                                    const/4 v0, 0x0
+                                    const-string v0, "other_string_long"
+                                    return-void
+                                """
+                            )
+                        }
+                    )
+                )
+
+            )
+        )
+
+        with(patcher.context.bytecodeContext) {
+            class ProxyFilterCounter(val filter: InstructionFilter) : InstructionFilter {
+                var matchesCallCount = 0
+
+                override fun matches(
+                    enclosingMethod: Method,
+                    instruction: Instruction
+                ): Boolean {
+                    matchesCallCount++
+                    return filter.matches(enclosingMethod, instruction)
+                }
+            }
+
+            val proxyFilter = ProxyFilterCounter(opcode(Opcode.CONST_4))
+            val fingerprint1 = Fingerprint(
+                filters = listOf(
+                    proxyFilter,
+                    string("string_example")
+                )
+            )
+
+            println("test 1")
+            proxyFilter.matchesCallCount = 0
+            fingerprint1.clearMatch()
+            assertEquals(
+                listOf(
+                    "Lclass1;",
+                    "Lclass2;",
+                ),
+                fingerprint1
+                    .matchAll()
+                    .map { it.originalClassDef.type }
+            )
+
+            // Should not do string lookup because of custom filter.
+            assertEquals(
+                11, proxyFilter.matchesCallCount,
+                "Number of expected filter calls did not match"
+            )
+
+
+            println("test 2")
+            // Add custom counter to bundled list so faster string lookup is used.
+            BUNDLED_INSTRUCTION_FILTERS += ProxyFilterCounter::class
+
+            proxyFilter.matchesCallCount = 0
+            assertEquals(
+                listOf(
+                    "Lclass1;",
+                    "Lclass2;", // to "method1",
+                ),
+                fingerprint1
+                    .matchAll()
+                    .map { it.originalClassDef.type }
+            )
+
+            // Matching now only checks methods with matching strings.
+            assertEquals(
+                2, proxyFilter.matchesCallCount,
+                "Number of expected filter calls did not match"
+            )
+
+
+            println("test 3")
+            assertEquals(
+                listOf(
+                    "Lclass1;"
+                ),
+                fingerprint1
+                    .matchAll(class1)
+                    .map { it.originalClassDef.type }
+            )
+
+            proxyFilter.matchesCallCount = 0
+            val fingerprint2 = Fingerprint(
+                filters = listOf(
+                    proxyFilter,
+                    string("string_example"),
+                )
+            )
+
+            println("test 4")
+            assertEquals(
+                listOf(
+                    "Lclass1;",
+                    "Lclass2;",
+                ),
+                fingerprint2
+                    .matchAll()
+                    .map { it.originalClassDef.type }
+            )
+            assertEquals(
+                2, proxyFilter.matchesCallCount,
+                "Number of expected filter calls did not match"
+            )
+
+
+            proxyFilter.matchesCallCount = 0
+            val fingerprint3 = Fingerprint(
+                filters = listOf(
+                    proxyFilter,
+                    string("string_example", comparison = StringComparisonType.CONTAINS)
+                )
+            )
+
+            assertEquals(
+                listOf(
+                    "Lclass1;",
+                    "Lclass2;",
+                    "Lclass3;",
+                ),
+                fingerprint3
+                    .matchAll()
+                    .map { it.originalClassDef.type }
+            )
+            // Check all methods containing strings since it's contains.
+            assertEquals(
+                9, proxyFilter.matchesCallCount,
+                "Number of expected filter calls did not match"
+            )
+
+            proxyFilter.matchesCallCount = 0
+            val fingerprint4 = Fingerprint(
+                filters = listOf(
+                    proxyFilter,
+                    string("non_existent_string")
+                )
+            )
+            assertThrows<Exception> {
+                fingerprint4.matchAll()
+            }
+            assertEquals(
+                0, proxyFilter.matchesCallCount,
+                "Number of expected filter calls did not match"
+            )
+        }
+    }
+
+    @Test
+    fun `legacy string matching order`() {
+        every { patcher.context.bytecodeContext.patchClasses } returns PatchClasses(
+            setOf(
+                ImmutableClassDef(
+                    "Lclass1;",
+                    0,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    listOf(
+                        ImmutableMethod(
+                            "Lclass1;",
+                            "method1",
+                            emptyList(),
+                            "Ljava/lang/String;",
+                            AccessFlags.PUBLIC.value,
+                            null,
+                            null,
+                            MutableMethodImplementation(1),
+                        ).toMutable().apply {
+                            addInstructions(
+                                0,
+                                """
+                                    const/4 v0, 0x0
+                                    const-string v0, "string_example_1"
+                                    const-string v0, "string_example_2"
+                                    const-string v0, "string_example_3"
+                                    return-void
+                                """
+                            )
+                        }
+                    )
+                )
+            )
+        )
+
+        val patches = setOf(
+            bytecodePatch {
+                execute {
+                    val fingerprint1 = Fingerprint(
+                        strings = listOf(
+                            "string_example_2",
+                            "string_example_1",
+                            "string_example_3",
+                        )
+                    )
+
+                    assertEquals(
+                        listOf(
+                            2,
+                            1,
+                            3
+                        ),
+                        fingerprint1.match().stringMatches.map { it.index }
+                    )
+                }
+            }
+        )
+
+        patches()
+    }
+
 
     @Test
     fun `String filter patcomparison types`() {

--- a/src/test/kotlin/app/morphe/patcher/util/PatchClassesTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/util/PatchClassesTest.kt
@@ -262,7 +262,7 @@ internal object PatchClassesTest {
 
     @Test
     fun `getClassFromOpcodeStringLiteral returns classes containing string`() {
-        val classes = patchClasses.getClassFromOpcodeStringLiteral("hello")
+        val classes = patchClasses.getClassesFromOpcodeStringLiteral("hello")
 
         assertNotNull(classes)
         assertEquals(2, classes.size)  // Class1 and Class3 both have "hello"
@@ -270,7 +270,7 @@ internal object PatchClassesTest {
 
     @Test
     fun `getClassFromOpcodeStringLiteral returns null for non-existent string`() {
-        val classes = patchClasses.getClassFromOpcodeStringLiteral("nonexistent")
+        val classes = patchClasses.getClassesFromOpcodeStringLiteral("nonexistent")
 
         assertNull(classes)
     }


### PR DESCRIPTION
Adds a `matchAll()` method to find all methods a fingerprint matches.

Notable use cases:
- [Replace all bytecode strings](https://github.com/MorpheApp/morphe-patcher/blob/dev/docs/2_2_1_fingerprinting.md#finding-all-methods-a-fingerprint-matches) using a single fingerprint and a few lines of code.
- Replace `classDefForEach{}` manual searching with `Fingerprint.matchAll().forEach {}`
- Process multiple methods using a single fingerprint instead of multiple fingerprints with duplicated/extracted logic.