### PR TITLE
fix: Set extractNativeLibs to value in manifest by default

### DIFF
--- a/api/morphe-patcher.api
+++ b/api/morphe-patcher.api
@@ -340,8 +340,8 @@ public final class app/morphe/patcher/apk/ApkMerger {
 	public fun <init> ()V
 	public fun <init> (Lapp/morphe/patcher/logging/Logger;)V
 	public synthetic fun <init> (Lapp/morphe/patcher/logging/Logger;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun merge (Ljava/io/File;Ljava/io/File;ZLjava/lang/String;ZZZ)V
-	public static synthetic fun merge$default (Lapp/morphe/patcher/apk/ApkMerger;Ljava/io/File;Ljava/io/File;ZLjava/lang/String;ZZZILjava/lang/Object;)V
+	public final fun merge (Ljava/io/File;Ljava/io/File;ZLjava/lang/String;ZLjava/lang/Boolean;Z)V
+	public static synthetic fun merge$default (Lapp/morphe/patcher/apk/ApkMerger;Ljava/io/File;Ljava/io/File;ZLjava/lang/String;ZLjava/lang/Boolean;ZILjava/lang/Object;)V
 }
 
 public final class app/morphe/patcher/apk/ApkSigner {

--- a/src/main/kotlin/app/morphe/patcher/apk/ApkMerger.kt
+++ b/src/main/kotlin/app/morphe/patcher/apk/ApkMerger.kt
@@ -46,7 +46,7 @@ class ApkMerger(
         validateModules: Boolean = true,
         resDirName: String? = null,
         validateResDir: Boolean = true,
-        extractNativeLibs: Boolean = false,
+        extractNativeLibs: Boolean? = null,
         cleanMetaInf: Boolean = true
     ) {
         ApkEditorUtil.delete(outputFile)
@@ -77,7 +77,9 @@ class ApkMerger(
         sanitizeManifest(mergedModule)
         mergedModule.refreshTable()
         mergedModule.refreshManifest()
-        mergedModule.setExtractNativeLibs(extractNativeLibs)
+        val shouldExtractNativeLibs = extractNativeLibs ?: mergedModule.androidManifest?.isExtractNativeLibs
+        logger.info("Setting extractNativeLibs=$shouldExtractNativeLibs")
+        mergedModule.setExtractNativeLibs(shouldExtractNativeLibs)
         logger.info("Writing apk ...")
         mergedModule.writeApk(outputFile)
         mergedModule.close()


### PR DESCRIPTION
Previously it was forced to false, which bloated final APK size in APKs that have this value set to true in the manifest.