### PR TITLE
fix: Remove overloaded deprecated patch 'use' constructor

### DIFF
--- a/api/morphe-patcher.api
+++ b/api/morphe-patcher.api
@@ -546,8 +546,8 @@ public final class app/morphe/patcher/patch/BytecodePatchContext : app/morphe/pa
 }
 
 public final class app/morphe/patcher/patch/Compatibility {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lapp/morphe/patcher/patch/ApkFileType;Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lapp/morphe/patcher/patch/ApkFileType;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lapp/morphe/patcher/patch/ApkFileType;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Lapp/morphe/patcher/patch/ApkFileType;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lapp/morphe/patcher/patch/ApkFileType;Ljava/lang/Integer;Ljava/util/Set;Ljava/util/List;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lapp/morphe/patcher/patch/ApkFileType;Ljava/lang/Integer;Ljava/util/Set;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lapp/morphe/patcher/patch/ApkFileType;Ljava/lang/String;Ljava/util/Set;Ljava/util/List;)V
@@ -753,21 +753,21 @@ public final class app/morphe/patcher/patch/PatchException : java/lang/Exception
 }
 
 public final class app/morphe/patcher/patch/PatchKt {
+	public static final fun bytecodePatch (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lapp/morphe/patcher/patch/BytecodePatch;
 	public static final fun bytecodePatch (Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Lapp/morphe/patcher/patch/BytecodePatch;
+	public static synthetic fun bytecodePatch$default (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lapp/morphe/patcher/patch/BytecodePatch;
 	public static synthetic fun bytecodePatch$default (Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lapp/morphe/patcher/patch/BytecodePatch;
-	public static final fun bytecodePatchLegacy (Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Lapp/morphe/patcher/patch/BytecodePatch;
-	public static synthetic fun bytecodePatchLegacy$default (Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lapp/morphe/patcher/patch/BytecodePatch;
 	public static final fun loadPatchesFromDex (Ljava/util/Set;Ljava/io/File;)Lapp/morphe/patcher/patch/PatchLoader$Dex;
 	public static synthetic fun loadPatchesFromDex$default (Ljava/util/Set;Ljava/io/File;ILjava/lang/Object;)Lapp/morphe/patcher/patch/PatchLoader$Dex;
 	public static final fun loadPatchesFromJar (Ljava/util/Set;)Lapp/morphe/patcher/patch/PatchLoader$Jar;
+	public static final fun rawResourcePatch (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lapp/morphe/patcher/patch/RawResourcePatch;
 	public static final fun rawResourcePatch (Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Lapp/morphe/patcher/patch/RawResourcePatch;
+	public static synthetic fun rawResourcePatch$default (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lapp/morphe/patcher/patch/RawResourcePatch;
 	public static synthetic fun rawResourcePatch$default (Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lapp/morphe/patcher/patch/RawResourcePatch;
-	public static final fun rawResourcePatchLegacy (Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Lapp/morphe/patcher/patch/RawResourcePatch;
-	public static synthetic fun rawResourcePatchLegacy$default (Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lapp/morphe/patcher/patch/RawResourcePatch;
+	public static final fun resourcePatch (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lapp/morphe/patcher/patch/ResourcePatch;
 	public static final fun resourcePatch (Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Lapp/morphe/patcher/patch/ResourcePatch;
+	public static synthetic fun resourcePatch$default (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lapp/morphe/patcher/patch/ResourcePatch;
 	public static synthetic fun resourcePatch$default (Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lapp/morphe/patcher/patch/ResourcePatch;
-	public static final fun resourcePatchLegacy (Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Lapp/morphe/patcher/patch/ResourcePatch;
-	public static synthetic fun resourcePatchLegacy$default (Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lapp/morphe/patcher/patch/ResourcePatch;
 }
 
 public abstract class app/morphe/patcher/patch/PatchLoader : java/util/Set, kotlin/jvm/internal/markers/KMappedMarker {

--- a/docs/2_2_patch_anatomy.md
+++ b/docs/2_2_patch_anatomy.md
@@ -8,13 +8,28 @@ The following example patch disables ads in an app.
 In the following sections, each part of the patch will be explained in detail.
 
 ```kt
-package app.Morphe.patches.ads
+
+// App compatibility declaration. See Compatibility class.
+val COMPATIBILITY_XYZ = Compatibility(
+  name = "XYZ App",
+  packageName = "app.xyz.mobile",
+  appIconColor = 0xFF3300, // App icon background color
+  targets = listOf(
+    AppTarget(
+      version = "2.0.0",
+    ),
+    AppTarget(
+      version = "1.0.42",
+    )
+  )
+)
 
 val disableAdsPatch = bytecodePatch(
     name = "Disable ads",
     description = "Disable ads in the app.",
+    default = true
 ) {
-    compatibleWith("com.some.app"("1.0.0"))
+    compatibleWith(COMPATIBILITY_XYZ)
 
     // Patches can depend on other patches, executing them first.
     dependsOn(disableAdsResourcePatch)
@@ -60,7 +75,7 @@ Multiple types are already built into Morphe Patcher and are supported by any ap
 To define an option, use the available `option` functions:
 
 ```kt
-val patch = bytecodePatch(name = "Patch") {
+val patch = bytecodePatch(name = "Patch", default = true) {
     // Add an inbuilt option and delegate it to a property.
     val value by stringOption(name = "Inbuilt option")
 
@@ -121,7 +136,7 @@ After compiling the above code as a DEX file, you can add the DEX file as a reso
 and use it in a patch:
 
 ```kt
-val complexPatch = bytecodePatch(name = "Complex patch") {
+val complexPatch = bytecodePatch(name = "Complex patch", default = true) {
     extendWith("complex-patch.mpe")
 
     execute {
@@ -151,7 +166,7 @@ A simple real-world example would be a patch that opens a resource file of the a
 Other patches that depend on this patch can write to the file, and the finalization block can close the file.
 
 ```kt
-val patch = bytecodePatch(name = "Patch") {
+val patch = bytecodePatch(name = "Patch", default = true) {
     dependsOn(
         bytecodePatch(name = "Dependency") {
             execute {

--- a/src/main/kotlin/app/morphe/patcher/patch/Compatibility.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/Compatibility.kt
@@ -149,19 +149,17 @@ data class Compatibility(
     /**
      * Convenience constructor for universal patches.
      *
-     * @param name Actual app name.
      * @param description User facing description of the app.
      * @param apkFileType Target unpatched app type. Currently only used for Manager UI presentation.
      * @param targets App targets. Versions are declared newest to oldest.
      */
     constructor(
-        name: String? = null,
         description: String? = null,
         apkFileType: ApkFileType? = null,
         targets: List<AppTarget>? = null,
     ) : this(
         packageName = null,
-        name = name,
+        name = null,
         description = description,
         apkFileType = apkFileType,
         appIconColor = null,

--- a/src/main/kotlin/app/morphe/patcher/patch/Patch.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/Patch.kt
@@ -570,10 +570,8 @@ class BytecodePatchBuilder internal constructor(
 /**
  * @deprecated Use [bytecodePatch] with `default` instead of `use`.
  */
-@JvmName("bytecodePatchLegacy")
-@Suppress("CONFLICTING_OVERLOADS")
 @Deprecated(
-    message = "Use 'default' parameter instead of 'use'",
+    message = "Use constructor with 'default' parameter",
     replaceWith = ReplaceWith(
         expression = "bytecodePatch(name, description, default = use, block)"
     ),
@@ -582,9 +580,8 @@ class BytecodePatchBuilder internal constructor(
 fun bytecodePatch(
     name: String? = null,
     description: String? = null,
-    use: Boolean = true,
     block: BytecodePatchBuilder.() -> Unit = {},
-) = bytecodePatch(name, description, default = use, block)
+) = bytecodePatch(name, description, default = true, block)
 
 /**
  * Create a new [BytecodePatch].
@@ -597,7 +594,6 @@ fun bytecodePatch(
  *
  * @return The created [BytecodePatch].
  */
-@Suppress("CONFLICTING_OVERLOADS")
 fun bytecodePatch(
     name: String? = null,
     description: String? = null,
@@ -635,10 +631,8 @@ class RawResourcePatchBuilder internal constructor(
 /**
  * @deprecated Use [rawResourcePatch] with `default` instead of `use`.
  */
-@JvmName("rawResourcePatchLegacy")
-@Suppress("CONFLICTING_OVERLOADS")
 @Deprecated(
-    message = "Use 'default' parameter instead of 'use'",
+    message = "Use constructor with 'default' parameter",
     replaceWith = ReplaceWith(
         expression = "rawResourcePatch(name, description, default = use, block)"
     ),
@@ -647,9 +641,8 @@ class RawResourcePatchBuilder internal constructor(
 fun rawResourcePatch(
     name: String? = null,
     description: String? = null,
-    use: Boolean = true,
     block: RawResourcePatchBuilder.() -> Unit = {},
-) = rawResourcePatch(name, description, default = use, block)
+) = rawResourcePatch(name, description, default = true, block)
 
 /**
  * Create a new [RawResourcePatch].
@@ -662,7 +655,6 @@ fun rawResourcePatch(
  *
  * @return The created [RawResourcePatch].
  */
-@Suppress("CONFLICTING_OVERLOADS")
 fun rawResourcePatch(
     name: String? = null,
     description: String? = null,
@@ -700,10 +692,8 @@ class ResourcePatchBuilder internal constructor(
 /**
  * @deprecated Use [resourcePatch] with `default` instead of `use`.
  */
-@JvmName("resourcePatchLegacy")
-@Suppress("CONFLICTING_OVERLOADS")
 @Deprecated(
-    message = "Use 'default' parameter instead of 'use'",
+    message = "Use constructor with 'default' parameter",
     replaceWith = ReplaceWith(
         expression = "resourcePatch(name, description, default = use, block)"
     ),
@@ -712,9 +702,8 @@ class ResourcePatchBuilder internal constructor(
 fun resourcePatch(
     name: String? = null,
     description: String? = null,
-    use: Boolean = true,
     block: ResourcePatchBuilder.() -> Unit = {},
-) = resourcePatch(name, description, default = use, block)
+) = resourcePatch(name, description, default = true, block)
 
 /**
  * Create a new [ResourcePatch].
@@ -727,7 +716,6 @@ fun resourcePatch(
  *
  * @return The created [ResourcePatch].
  */
-@Suppress("CONFLICTING_OVERLOADS")
 fun resourcePatch(
     name: String? = null,
     description: String? = null,

--- a/src/test/kotlin/app/morphe/patcher/PatcherTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/PatcherTest.kt
@@ -73,14 +73,14 @@ internal object PatcherTest {
         val executed = mutableListOf<String>()
 
         val patches = setOf(
-            bytecodePatch { execute { executed += "1" } },
-            bytecodePatch {
+            bytecodePatch(default = true) {  execute { executed += "1" } },
+            bytecodePatch(default = true)  {
                 dependsOn(
-                    bytecodePatch {
+                    bytecodePatch(default = true)  {
                         execute { executed += "2" }
                         finalize { executed += "-2" }
                     },
-                    bytecodePatch { execute { executed += "3" } },
+                    bytecodePatch(default = true)  { execute { executed += "3" } },
                 )
 
                 execute { executed += "4" }
@@ -116,9 +116,9 @@ internal object PatcherTest {
 
         // No patches execute successfully,
         // because the dependency patch throws an exception inside the execute block.
-        bytecodePatch {
+        bytecodePatch(default = true)  {
             dependsOn(
-                bytecodePatch {
+                bytecodePatch(default = true)  {
                     execute { throw PatchException("1") }
                     finalize { executed += "-2" }
                 },
@@ -132,9 +132,9 @@ internal object PatcherTest {
         // because only the dependant patch throws an exception inside the finalize block.
         // Patches that depend on a failed patch should not be executed,
         // but patches that are depended on by a failed patch should be executed.
-        bytecodePatch {
+        bytecodePatch(default = true)  {
             dependsOn(
-                bytecodePatch {
+                bytecodePatch(default = true)  {
                     execute { executed += "1" }
                     finalize { executed += "-2" }
                 },
@@ -146,9 +146,9 @@ internal object PatcherTest {
 
         // Because the finalize block of the dependency patch is executed after the finalize block of the dependant patch,
         // the dependant patch executes successfully, but the dependency patch raises an exception in the finalize block.
-        bytecodePatch {
+        bytecodePatch(default = true)  {
             dependsOn(
-                bytecodePatch {
+                bytecodePatch(default = true)  {
                     execute { executed += "1" }
                     finalize { throw PatchException("-2") }
                 },
@@ -162,9 +162,9 @@ internal object PatcherTest {
         // because the dependant patch raises an exception in the finalize block.
         // Patches that depend on a failed patch should not be executed,
         // but patches that are depended on by a failed patch should be executed.
-        bytecodePatch {
+        bytecodePatch(default = true)  {
             dependsOn(
-                bytecodePatch {
+                bytecodePatch(default = true)  {
                     execute { executed += "1" }
                     finalize { executed += "-2" }
                 },
@@ -251,7 +251,7 @@ internal object PatcherTest {
         }
 
         val patches = setOf(
-            bytecodePatch {
+            bytecodePatch(default = true)  {
                 execute {
                     val class1 = patchClasses.classMap.values.first().classDef
                     println("class1: $class1")
@@ -656,7 +656,7 @@ internal object PatcherTest {
         )
 
         val patches = setOf(
-            bytecodePatch {
+            bytecodePatch(default = true)  {
                 execute {
                     val fingerprint1 = Fingerprint(
                         strings = listOf(

--- a/src/test/kotlin/app/morphe/patcher/patch/CompatibilityTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/patch/CompatibilityTest.kt
@@ -14,7 +14,7 @@ internal object CompatibilityTest {
 
     @Test
     fun `legacy usage`() {
-        val patch = bytecodePatch(name = "Test") {
+        val patch = bytecodePatch(name = "Test", default = true) {
             compatibleWith(
                 "compatible.package"("1.0.0"),
             )
@@ -26,7 +26,7 @@ internal object CompatibilityTest {
 
     @Test
     fun `legacy to Compatibility`() {
-        var patch = bytecodePatch(name = "Test") {
+        var patch = bytecodePatch(name = "Test", default = true) {
             compatibleWith(
                 "compatible.package"("1.0.0"),
             )
@@ -36,7 +36,7 @@ internal object CompatibilityTest {
             patch.compatibility!!.first().targets
         )
 
-        patch = bytecodePatch(name = "Test") {
+        patch = bytecodePatch(name = "Test", default = true) {
             compatibleWith(
                 "compatible.package",
             )

--- a/src/test/kotlin/app/morphe/patcher/patch/PatchLoaderTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/patch/PatchLoaderTest.kt
@@ -14,26 +14,26 @@ import kotlin.test.assertEquals
 // region Test patches.
 
 // Not loaded, because it's unnamed.
-val publicUnnamedPatch = bytecodePatch {
+val publicUnnamedPatch = bytecodePatch(default = true) {
 }
 
 // Loaded, because it's named.
-val publicPatch = bytecodePatch("Public") {
+val publicPatch = bytecodePatch("Public", default = true) {
 }
 
 // Not loaded, because it's private.
-private val privateUnnamedPatch = bytecodePatch {
+private val privateUnnamedPatch = bytecodePatch(default = true) {
 }
 
 // Not loaded, because it's private.
-private val privatePatch = bytecodePatch("Private") {
+private val privatePatch = bytecodePatch("Private", default = true) {
 }
 
 // Not loaded, because it's unnamed.
 fun publicUnnamedPatchFunction() = publicUnnamedPatch
 
 // Loaded, because it's named.
-fun publicNamedPatchFunction() = bytecodePatch("Public") { }
+fun publicNamedPatchFunction() = bytecodePatch("Public", default = true) { }
 
 // Not loaded, because it's parameterized.
 fun parameterizedFunction(@Suppress("UNUSED_PARAMETER") param: Any) = publicNamedPatchFunction()

--- a/src/test/kotlin/app/morphe/patcher/patch/PatchTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/patch/PatchTest.kt
@@ -6,14 +6,14 @@ import kotlin.test.assertEquals
 internal object PatchTest {
     @Test
     fun `can create patch with name`() {
-        val patch = bytecodePatch(name = "Test") {}
+        val patch = bytecodePatch(name = "Test", default = true) {}
 
         assertEquals("Test", patch.name)
     }
 
     @Test
     fun `can create patch with compatible packages`() {
-        val patch = bytecodePatch(name = "Test") {
+        val patch = bytecodePatch(name = "Test", default = true) {
             compatibleWith(
                 "compatible.package"("1.0.0"),
             )
@@ -25,8 +25,8 @@ internal object PatchTest {
 
     @Test
     fun `can create patch with dependencies`() {
-        val patch = bytecodePatch(name = "Test") {
-            dependsOn(resourcePatch {})
+        val patch = bytecodePatch(name = "Test", default = true) {
+            dependsOn(resourcePatch(default = true) {})
         }
 
         assertEquals(1, patch.dependencies.size)
@@ -34,7 +34,7 @@ internal object PatchTest {
 
     @Test
     fun `can create patch with options`() {
-        val patch = bytecodePatch(name = "Test") {
+        val patch = bytecodePatch(name = "Test", default = true) {
             val print by stringOption("print")
             val custom = option<String>("custom")()
 

--- a/src/test/kotlin/app/morphe/patcher/patch/SetOptionsTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/patch/SetOptionsTest.kt
@@ -15,14 +15,14 @@ internal class OptionsTest {
             "Test patch" to mapOf("key1" to "test", "key2" to false),
         )
 
-        val patch = bytecodePatch("Test patch") {
+        val patch = bytecodePatch("Test patch", default = true) {
             stringOption("key1")
             booleanOption("key2", true)
         }
-        val duplicatePatch = bytecodePatch("Test patch") {
+        val duplicatePatch = bytecodePatch("Test patch", default = true) {
             stringOption("key1")
         }
-        val unnamedPatch = bytecodePatch {
+        val unnamedPatch = bytecodePatch(default = true) {
             booleanOption("key1")
         }
 

--- a/src/test/kotlin/app/morphe/patcher/patch/options/OptionsTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/patch/options/OptionsTest.kt
@@ -9,7 +9,7 @@ import kotlin.test.*
 internal object OptionsTest {
     private val externalOption = stringOption("external", "default")
 
-    private val optionsTestPatch = bytecodePatch {
+    private val optionsTestPatch = bytecodePatch(default = true) {
         externalOption()
 
         booleanOption("bool", true)
@@ -72,7 +72,7 @@ internal object OptionsTest {
     @Test
     fun `should be able to add options manually`() = options {
         assertDoesNotThrow {
-            bytecodePatch {
+            bytecodePatch(default = true) {
                 get("list")()
             }.options["list"]
         }


### PR DESCRIPTION
Removes duplicate overloaded 'use' constructor. The existing renamed constructor has binary backwards compatibility and is verified to work with old patch bundles.

Removes unused typo parameter in app name constructor.

Updates documentation examples.
