### PR TITLE
fix: Restore binary backwards compatibility

### DIFF
--- a/api/morphe-patcher.api
+++ b/api/morphe-patcher.api
@@ -512,6 +512,7 @@ public final class app/morphe/patcher/patch/AppTarget : java/lang/Comparable {
 
 public final class app/morphe/patcher/patch/BytecodePatch : app/morphe/patcher/patch/Patch {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/util/Set;Ljava/util/Set;Ljava/util/function/Supplier;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/util/Set;Ljava/util/Set;Ljava/util/function/Supplier;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getExtensionInputStream ()Ljava/util/function/Supplier;
 	public fun toString ()Ljava/lang/String;
 }
@@ -753,20 +754,14 @@ public final class app/morphe/patcher/patch/PatchException : java/lang/Exception
 }
 
 public final class app/morphe/patcher/patch/PatchKt {
-	public static final fun bytecodePatch (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lapp/morphe/patcher/patch/BytecodePatch;
 	public static final fun bytecodePatch (Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Lapp/morphe/patcher/patch/BytecodePatch;
-	public static synthetic fun bytecodePatch$default (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lapp/morphe/patcher/patch/BytecodePatch;
 	public static synthetic fun bytecodePatch$default (Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lapp/morphe/patcher/patch/BytecodePatch;
 	public static final fun loadPatchesFromDex (Ljava/util/Set;Ljava/io/File;)Lapp/morphe/patcher/patch/PatchLoader$Dex;
 	public static synthetic fun loadPatchesFromDex$default (Ljava/util/Set;Ljava/io/File;ILjava/lang/Object;)Lapp/morphe/patcher/patch/PatchLoader$Dex;
 	public static final fun loadPatchesFromJar (Ljava/util/Set;)Lapp/morphe/patcher/patch/PatchLoader$Jar;
-	public static final fun rawResourcePatch (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lapp/morphe/patcher/patch/RawResourcePatch;
 	public static final fun rawResourcePatch (Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Lapp/morphe/patcher/patch/RawResourcePatch;
-	public static synthetic fun rawResourcePatch$default (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lapp/morphe/patcher/patch/RawResourcePatch;
 	public static synthetic fun rawResourcePatch$default (Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lapp/morphe/patcher/patch/RawResourcePatch;
-	public static final fun resourcePatch (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lapp/morphe/patcher/patch/ResourcePatch;
 	public static final fun resourcePatch (Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Lapp/morphe/patcher/patch/ResourcePatch;
-	public static synthetic fun resourcePatch$default (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lapp/morphe/patcher/patch/ResourcePatch;
 	public static synthetic fun resourcePatch$default (Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lapp/morphe/patcher/patch/ResourcePatch;
 }
 

--- a/src/main/kotlin/app/morphe/patcher/patch/Patch.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/Patch.kt
@@ -198,7 +198,7 @@ class BytecodePatch internal constructor(
     constructor(
         name: String?,
         description: String?,
-        use: Boolean,
+        use: Boolean = true,
         compatiblePackages: Set<Package>?,
         dependencies: Set<Patch<*>>,
         options: Set<Option<*>>,
@@ -568,22 +568,6 @@ class BytecodePatchBuilder internal constructor(
 }
 
 /**
- * @deprecated Use [bytecodePatch] with `default` instead of `use`.
- */
-@Deprecated(
-    message = "Use constructor with 'default' parameter",
-    replaceWith = ReplaceWith(
-        expression = "bytecodePatch(name, description, default = use, block)"
-    ),
-    level = DeprecationLevel.WARNING
-)
-fun bytecodePatch(
-    name: String? = null,
-    description: String? = null,
-    block: BytecodePatchBuilder.() -> Unit = {},
-) = bytecodePatch(name, description, default = true, block)
-
-/**
  * Create a new [BytecodePatch].
  *
  * @param name The name of the patch.
@@ -597,7 +581,7 @@ fun bytecodePatch(
 fun bytecodePatch(
     name: String? = null,
     description: String? = null,
-    default: Boolean,
+    default: Boolean = true,
     block: BytecodePatchBuilder.() -> Unit = {},
 ) = BytecodePatchBuilder(name, description, default).buildPatch(block) as BytecodePatch
 
@@ -614,7 +598,7 @@ fun bytecodePatch(
 class RawResourcePatchBuilder internal constructor(
     name: String?,
     description: String?,
-    default: Boolean,
+    default: Boolean = true,
 ) : PatchBuilder<ResourcePatchContext>(name, description, default) {
     override fun build() = RawResourcePatch(
         name,
@@ -627,22 +611,6 @@ class RawResourcePatchBuilder internal constructor(
         finalizeBlock,
     )
 }
-
-/**
- * @deprecated Use [rawResourcePatch] with `default` instead of `use`.
- */
-@Deprecated(
-    message = "Use constructor with 'default' parameter",
-    replaceWith = ReplaceWith(
-        expression = "rawResourcePatch(name, description, default = use, block)"
-    ),
-    level = DeprecationLevel.WARNING
-)
-fun rawResourcePatch(
-    name: String? = null,
-    description: String? = null,
-    block: RawResourcePatchBuilder.() -> Unit = {},
-) = rawResourcePatch(name, description, default = true, block)
 
 /**
  * Create a new [RawResourcePatch].
@@ -658,7 +626,7 @@ fun rawResourcePatch(
 fun rawResourcePatch(
     name: String? = null,
     description: String? = null,
-    default: Boolean,
+    default: Boolean = true,
     block: RawResourcePatchBuilder.() -> Unit = {},
 ) = RawResourcePatchBuilder(name, description, default).buildPatch(block) as RawResourcePatch
 
@@ -675,7 +643,7 @@ fun rawResourcePatch(
 class ResourcePatchBuilder internal constructor(
     name: String?,
     description: String?,
-    default: Boolean,
+    default: Boolean = true,
 ) : PatchBuilder<ResourcePatchContext>(name, description, default) {
     override fun build() = ResourcePatch(
         name,
@@ -688,22 +656,6 @@ class ResourcePatchBuilder internal constructor(
         finalizeBlock,
     )
 }
-
-/**
- * @deprecated Use [resourcePatch] with `default` instead of `use`.
- */
-@Deprecated(
-    message = "Use constructor with 'default' parameter",
-    replaceWith = ReplaceWith(
-        expression = "resourcePatch(name, description, default = use, block)"
-    ),
-    level = DeprecationLevel.WARNING
-)
-fun resourcePatch(
-    name: String? = null,
-    description: String? = null,
-    block: ResourcePatchBuilder.() -> Unit = {},
-) = resourcePatch(name, description, default = true, block)
 
 /**
  * Create a new [ResourcePatch].
@@ -719,7 +671,7 @@ fun resourcePatch(
 fun resourcePatch(
     name: String? = null,
     description: String? = null,
-    default: Boolean,
+    default: Boolean = true,
     block: ResourcePatchBuilder.() -> Unit = {},
 ) = ResourcePatchBuilder(name, description, default).buildPatch(block) as ResourcePatch
 

--- a/src/test/kotlin/app/morphe/patcher/patch/CompatibilityTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/patch/CompatibilityTest.kt
@@ -14,7 +14,7 @@ internal object CompatibilityTest {
 
     @Test
     fun `legacy usage`() {
-        val patch = bytecodePatch(name = "Test", default = true) {
+        val patch = bytecodePatch(name = "Test") {
             compatibleWith(
                 "compatible.package"("1.0.0"),
             )
@@ -26,7 +26,7 @@ internal object CompatibilityTest {
 
     @Test
     fun `legacy to Compatibility`() {
-        var patch = bytecodePatch(name = "Test", default = true) {
+        var patch = bytecodePatch(name = "Test") {
             compatibleWith(
                 "compatible.package"("1.0.0"),
             )
@@ -36,7 +36,7 @@ internal object CompatibilityTest {
             patch.compatibility!!.first().targets
         )
 
-        patch = bytecodePatch(name = "Test", default = true) {
+        patch = bytecodePatch(name = "Test") {
             compatibleWith(
                 "compatible.package",
             )

--- a/src/test/kotlin/app/morphe/patcher/patch/MostCommonCompatibleVersionsTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/patch/MostCommonCompatibleVersionsTest.kt
@@ -28,7 +28,7 @@ internal class MostCommonCompatibleVersionsTest {
     fun `empty because package is incompatible with any version`() {
         assertEqualsVersions(
             expected = mapOf("some.package" to linkedMapOf()),
-            patches = setOf(newPatch("some.package", emptySet(), default = true)),
+            patches = setOf(newPatch("some.package", emptySet())),
             compatiblePackageNames = setOf("some.package"),
         )
     }

--- a/src/test/kotlin/app/morphe/patcher/patch/PatchLoaderTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/patch/PatchLoaderTest.kt
@@ -18,7 +18,7 @@ val publicUnnamedPatch = bytecodePatch(default = true) {
 }
 
 // Loaded, because it's named.
-val publicPatch = bytecodePatch("Public", default = true) {
+val publicPatch = bytecodePatch("Public") {
 }
 
 // Not loaded, because it's private.
@@ -26,14 +26,14 @@ private val privateUnnamedPatch = bytecodePatch(default = true) {
 }
 
 // Not loaded, because it's private.
-private val privatePatch = bytecodePatch("Private", default = true) {
+private val privatePatch = bytecodePatch("Private") {
 }
 
 // Not loaded, because it's unnamed.
 fun publicUnnamedPatchFunction() = publicUnnamedPatch
 
 // Loaded, because it's named.
-fun publicNamedPatchFunction() = bytecodePatch("Public", default = true) { }
+fun publicNamedPatchFunction() = bytecodePatch("Public") { }
 
 // Not loaded, because it's parameterized.
 fun parameterizedFunction(@Suppress("UNUSED_PARAMETER") param: Any) = publicNamedPatchFunction()

--- a/src/test/kotlin/app/morphe/patcher/patch/PatchTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/patch/PatchTest.kt
@@ -6,14 +6,14 @@ import kotlin.test.assertEquals
 internal object PatchTest {
     @Test
     fun `can create patch with name`() {
-        val patch = bytecodePatch(name = "Test", default = true) {}
+        val patch = bytecodePatch(name = "Test") {}
 
         assertEquals("Test", patch.name)
     }
 
     @Test
     fun `can create patch with compatible packages`() {
-        val patch = bytecodePatch(name = "Test", default = true) {
+        val patch = bytecodePatch(name = "Test") {
             compatibleWith(
                 "compatible.package"("1.0.0"),
             )
@@ -25,7 +25,7 @@ internal object PatchTest {
 
     @Test
     fun `can create patch with dependencies`() {
-        val patch = bytecodePatch(name = "Test", default = true) {
+        val patch = bytecodePatch(name = "Test") {
             dependsOn(resourcePatch(default = true) {})
         }
 
@@ -34,7 +34,7 @@ internal object PatchTest {
 
     @Test
     fun `can create patch with options`() {
-        val patch = bytecodePatch(name = "Test", default = true) {
+        val patch = bytecodePatch(name = "Test") {
             val print by stringOption("print")
             val custom = option<String>("custom")()
 

--- a/src/test/kotlin/app/morphe/patcher/patch/SetOptionsTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/patch/SetOptionsTest.kt
@@ -15,11 +15,11 @@ internal class OptionsTest {
             "Test patch" to mapOf("key1" to "test", "key2" to false),
         )
 
-        val patch = bytecodePatch("Test patch", default = true) {
+        val patch = bytecodePatch("Test patch") {
             stringOption("key1")
             booleanOption("key2", true)
         }
-        val duplicatePatch = bytecodePatch("Test patch", default = true) {
+        val duplicatePatch = bytecodePatch("Test patch") {
             stringOption("key1")
         }
         val unnamedPatch = bytecodePatch(default = true) {


### PR DESCRIPTION
Fixes binary backwards compatibility issues introduced when `use` parameter was changed to mandatory.

Restores the `default = true` behavior that was previously present so prior mpp files continue to work as expected.