### PR TITLE
feat: Add `matchAll(range)` to validate the number of matches

### DIFF
--- a/api/morphe-patcher.api
+++ b/api/morphe-patcher.api
@@ -53,6 +53,8 @@ public class app/morphe/patcher/Fingerprint {
 	public final fun match (Lapp/morphe/patcher/patch/BytecodePatchContext;Lcom/android/tools/smali/dexlib2/iface/Method;Lcom/android/tools/smali/dexlib2/iface/ClassDef;)Lapp/morphe/patcher/Match;
 	public final fun matchAll (Lapp/morphe/patcher/patch/BytecodePatchContext;)Ljava/util/List;
 	public final fun matchAll (Lapp/morphe/patcher/patch/BytecodePatchContext;Lcom/android/tools/smali/dexlib2/iface/ClassDef;)Ljava/util/List;
+	public final fun matchAll (Lapp/morphe/patcher/patch/BytecodePatchContext;Lcom/android/tools/smali/dexlib2/iface/ClassDef;Lkotlin/ranges/IntRange;)Ljava/util/List;
+	public final fun matchAll (Lapp/morphe/patcher/patch/BytecodePatchContext;Lkotlin/ranges/IntRange;)Ljava/util/List;
 	public final fun matchAllOrNull (Lapp/morphe/patcher/patch/BytecodePatchContext;)Ljava/util/List;
 	public final fun matchAllOrNull (Lapp/morphe/patcher/patch/BytecodePatchContext;Lcom/android/tools/smali/dexlib2/iface/ClassDef;)Ljava/util/List;
 	public final fun matchOrNull (Lapp/morphe/patcher/patch/BytecodePatchContext;)Lapp/morphe/patcher/Match;

--- a/src/main/kotlin/app/morphe/patcher/Fingerprint.kt
+++ b/src/main/kotlin/app/morphe/patcher/Fingerprint.kt
@@ -702,7 +702,7 @@ open class Fingerprint private constructor(
      *
      * @param classDef The class the method is a member of.
      * @return All methods that match.
-     * @throws PatchException If the fingerprint failed to match.
+     * @throws PatchException If the fingerprint failed to match methods.
      */
     context(BytecodePatchContext)
     fun matchAll(
@@ -710,13 +710,63 @@ open class Fingerprint private constructor(
     ) = matchAllOrNull(classDef) ?: throw patchException()
 
     /**
-     * Match all methods in the target app.
+     * Matches all methods in the target app, requiring the number of matches
+     * to be in the specified range. A range including zero is allowed and
+     * returns an empty list if no matches exist.
      *
+     * @param classDef The class the method is a member of.
      * @return All methods that match.
      * @throws PatchException If the fingerprint failed to match.
      */
     context(BytecodePatchContext)
+    fun matchAll(classDef: ClassDef, range: IntRange): List<Match> {
+        val matches = matchAllOrNull(classDef)
+
+        return checkMatchesRange(matches, range)
+    }
+
+    /**
+     * Match all methods in the target app.
+     *
+     * @return All methods that match.
+     * @throws PatchException If the fingerprint failed to match any methods.
+     */
+    context(BytecodePatchContext)
     fun matchAll() = matchAllOrNull() ?: throw patchException()
+
+    /**
+     * Match all methods in the target app, requiring the number of matches to be
+     * in the specified range. A range including zero is allowed and returns an
+     * empty list if no matches exist.
+     *
+     * @return All methods that match.
+     * @throws PatchException If the number of matches is outside the range of [range].
+     */
+    context(BytecodePatchContext)
+    fun matchAll(range: IntRange): List<Match> {
+        val matches = matchAllOrNull()
+
+        return checkMatchesRange(matches, range)
+    }
+
+    private fun checkMatchesRange(
+        matches: List<Match>?,
+        range: IntRange
+    ): List<Match> {
+        if (matches == null) {
+            if (range.first == 0) {
+                return emptyList()
+            }
+            throw patchException()
+        }
+
+        if (matches.size !in range) {
+            throw PatchException("Expected a number of matches in $range but instead found ${matches.size}: $this")
+        }
+
+        return matches
+    }
+
 
     /**
      * The class the matching method is a member of, or null if this fingerprint did not match.

--- a/src/test/kotlin/app/morphe/patcher/PatcherTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/PatcherTest.kt
@@ -30,6 +30,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
+import jdk.internal.module.ModuleBootstrap.patcher
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.BeforeEach
@@ -253,11 +254,6 @@ internal object PatcherTest {
         val patches = setOf(
             bytecodePatch(default = true)  {
                 execute {
-                    val class1 = patchClasses.classMap.values.first().classDef
-                    println("class1: $class1")
-                    val class2 = patchClasses.classMap.values.last().classDef
-                    println("class2: $class2")
-
                     fingerprint1.match(patchClasses.classMap.values.first().classDef.methods.first())
                     fingerprint2.match(patchClasses.classMap.values.first().classDef)
                     fingerprint3.originalClassDef
@@ -273,8 +269,6 @@ internal object PatcherTest {
         patches()
 
         with(patcher.context.bytecodeContext) {
-            println("fingerprint4.originalClassDef.type: ")
-            println(fingerprint4.originalClassDef.type)
             assertEquals(fingerprint4.originalClassDef.type, "Lclass2;")
             assertEquals(fingerprint5.originalClassDef.type, "Lclass2;")
 
@@ -285,7 +279,6 @@ internal object PatcherTest {
                 { assertNotNull(fingerprint3.originalClassDefOrNull) },
             )
 
-            println("fingerprint5.originalClassDef: ${fingerprint5.originalClassDef}")
             assertAll(
                 "classFingerprint resolves",
                 {
@@ -499,7 +492,6 @@ internal object PatcherTest {
                 )
             )
 
-            println("test 1")
             proxyFilter.matchesCallCount = 0
             fingerprint1.clearMatch()
             assertEquals(
@@ -519,7 +511,6 @@ internal object PatcherTest {
             )
 
 
-            println("test 2")
             // Add custom counter to bundled list so faster string lookup is used.
             BUNDLED_INSTRUCTION_FILTERS += ProxyFilterCounter::class
 
@@ -541,7 +532,6 @@ internal object PatcherTest {
             )
 
 
-            println("test 3")
             assertEquals(
                 listOf(
                     "Lclass1;"
@@ -559,7 +549,6 @@ internal object PatcherTest {
                 )
             )
 
-            println("test 4")
             assertEquals(
                 listOf(
                     "Lclass1;",
@@ -599,6 +588,16 @@ internal object PatcherTest {
                 "Number of expected filter calls did not match"
             )
 
+            assertThrows<Exception> {
+                fingerprint3.matchAll(0 .. 2)
+            }
+
+            assertThrows<Exception> {
+                fingerprint3.matchAll(4 .. 100)
+            }
+
+            assertEquals(3, fingerprint3.matchAll(1 .. 3).size)
+
             proxyFilter.matchesCallCount = 0
             val fingerprint4 = Fingerprint(
                 filters = listOf(
@@ -609,6 +608,7 @@ internal object PatcherTest {
             assertThrows<Exception> {
                 fingerprint4.matchAll()
             }
+            assertEquals(0, fingerprint4.matchAll(0 .. 3).size)
             assertEquals(
                 0, proxyFilter.matchesCallCount,
                 "Number of expected filter calls did not match"


### PR DESCRIPTION
Adds a matchAll() range parameter to simplify patch code that expected a specific number of matches.

Example usage: https://github.com/MorpheApp/morphe-patches/commit/156c0e585c50307d3da8f478790d7193d97c1f0b