### PR TITLE
fix: Return defensive copy from `ArsclibResourceCoder.getDeletedFiles`

### DIFF
--- a/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
@@ -6,6 +6,8 @@
 package app.morphe.patcher.resource.coder
 
 import app.morphe.patcher.PackageMetadata
+import app.morphe.patcher.Patcher
+import app.morphe.patcher.PatcherResult
 import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.resource.CpuArchitecture
 import app.morphe.patcher.resource.PathMap
@@ -13,9 +15,9 @@ import app.morphe.patcher.resource.PublicXmlManager
 import app.morphe.patcher.resource.ResourceMode
 import app.morphe.patcher.resource.UncompressedFiles
 import app.morphe.patcher.resource.processor.AaptMacroProcessor
-import app.morphe.patcher.resource.processor.StringsXmlEscapeProcessor
 import app.morphe.patcher.resource.processor.PackageRenamingProcessor
 import app.morphe.patcher.resource.processor.ResourceIdProcessor
+import app.morphe.patcher.resource.processor.StringsXmlEscapeProcessor
 import app.morphe.patcher.resource.processor.StringsXmlSanitizeProcessor
 import app.morphe.patcher.resource.processor.StringsXmlUnEscapeProcessor
 import app.morphe.patcher.util.Document
@@ -369,12 +371,15 @@ class ArsclibResourceCoder(
      * Returns the relative paths (in-zip APK paths, e.g: "lib/armeabi-v7a/libfoo.so")
      * of files that existed at decode time but are no longer present on disk after
      * patches and resource transformations have run. Populated by [detectFileChanges].
-     * [PatcherResult.applyTo] uses this set to exclude entries from the rebuilt apk when assembling the output from the original input.
-     * Defensive copy: [close] clears [deletedFiles], and callers commonly hold this result past the enclosing [Patcher] `use` block via
-     * [PatcherResult.PatchedResources.deleteResources]. Returning the raw reference caused applyTo to read an empty set and
-     * silently skip every deletion, leaving stripped native libs in the final APK.
-     * Adding a .toSet() returns an independent snapshot instead of a live reference to [deletedFiles].
-     * close() clears the backing field, and applyTo typically runs after the Patcher.use block exits.
+     * [PatcherResult] uses this set to exclude entries from the rebuilt apk when
+     * assembling the output from the original input.
+     *
+     * Defensive copy: [close] clears [deletedFiles], and callers commonly hold this result past
+     * the enclosing [Patcher] `use` block via [PatcherResult.PatchedResources.deleteResources].
+     * Returning the raw reference caused `applyTo` to read an empty set and silently skip every
+     * deletion, leaving stripped native libs in the final APK. Adding a `.toSet()` returns an
+     * independent snapshot instead of a live reference to [deletedFiles] `.close()` clears the
+     * backing field, and `applyTo` typically runs after the [Patcher] `.use` block exits.
      */
     override fun getDeletedFiles(): Set<String> = deletedFiles.toSet()
 

--- a/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
@@ -370,8 +370,13 @@ class ArsclibResourceCoder(
      * of files that existed at decode time but are no longer present on disk after
      * patches and resource transformations have run. Populated by [detectFileChanges].
      * [PatcherResult.applyTo] uses this set to exclude entries from the rebuilt apk when assembling the output from the original input.
+     * Defensive copy: [close] clears [deletedFiles], and callers commonly hold this result past the enclosing [Patcher] `use` block via
+     * [PatcherResult.PatchedResources.deleteResources]. Returning the raw reference caused applyTo to read an empty set and
+     * silently skip every deletion, leaving stripped native libs in the final APK.
+     * Adding a .toSet() returns an independent snapshot instead of a live reference to [deletedFiles].
+     * close() clears the backing field, and applyTo typically runs after the Patcher.use block exits.
      */
-    override fun getDeletedFiles(): Set<String> = deletedFiles
+    override fun getDeletedFiles(): Set<String> = deletedFiles.toSet()
 
     /**
      * Get a file from the working directory.

--- a/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
@@ -1370,4 +1370,40 @@ internal class ArsclibResourceCoderTest {
             "Expected 3 total deletions, got: $deleted"
         )
     }
+
+    /**
+     * Regression test for the bug where PatcherResult.applyTo silently skipped all
+     * native-lib deletions when invoked after the enclosing Patcher.use block exited.
+     * Root cause: getDeletedFiles() used to return the internal mutable deletedFiles field by reference.
+     * close() clears that field. Callers holding the returned Set (via PatcherResult.PatchedResources.deleteResources)
+     * saw an empty set after close(), so applyTo had nothing to delete.
+     * Fix: getDeletedFiles() now returns a defensive copy via .toSet().
+     */
+    @Test
+    fun `getDeletedFiles returns independent snapshot that survives close`(@TempDir tempDir: File) {
+        val archCoder = createCoderWithKeepArchitectures(tempDir,
+            setOf(CpuArchitecture.ARM64_V8A))
+
+        setupNativeLibDirs(listOf("arm64-v8a", "x86", "x86_64"))
+        archCoder.fileSnapshotCache = archCoder.buildFileSnapshot()
+        archCoder.stripNativeLibraries()
+        archCoder.detectFileChanges()
+
+        // Capture the returned set BEFORE close, mimicking what PatcherResult.PatchedResources.deleteResources does in real usage.
+        val snapshot = archCoder.getDeletedFiles()
+        val sizeBeforeClose = snapshot.size
+        assertTrue(sizeBeforeClose > 0, "Sanity check: strip should have produced deletions")
+
+        // close() clears the internal deletedFiles backing field.
+        archCoder.close()
+
+        // The previously-returned set must retain its contents. If getDeletedFiles() had returned the raw reference,
+        // close() would have cleared it and size would be 0.
+        assertEquals(
+            sizeBeforeClose,
+            snapshot.size,
+            "getDeletedFiles must return an independent snapshot. close() cleared the shared reference and caused the silent strip-libs failure."
+        )
+    }
+
 }


### PR DESCRIPTION
Two protagonists of our story:
`getDeletedFiles()` -> returns a reference.
`patcher.close()` -> clears the deletedFiles. 

Now, both cli and gui get a reference from `getDeletedFiles()` but they use that reference at different times. It worked on the gui because gui uses it before `.close()` is called.
The cli however uses it after calling `.close()`. The reference still points to the same internal set but close() cleared that set, so cli gets an empty set. Empty set means no libs needs to be cleared and BAM, our resultant apk has all the libs but the logs still report that we cleared the libs.

Now, I don't know if we should enforce a pattern here,i.e, callers need to consume the set before `.close()` is called but what I went with is simply create a defensive copy. Regardless of when `.close()` gets called, a copy is passed to both cli and gui instead of a reference.