### PR TITLE
feat: `AppTarget` `versionCodes` field to restrict patching to specific version code releases

### DIFF
--- a/api/morphe-patcher.api
+++ b/api/morphe-patcher.api
@@ -534,26 +534,28 @@ public final class app/morphe/patcher/patch/ApkFileType : java/lang/Enum {
 }
 
 public final class app/morphe/patcher/patch/AppTarget : java/lang/Comparable {
+	public fun <init> (Ljava/lang/String;IZLjava/lang/Integer;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;IZLjava/lang/Integer;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;ZLjava/lang/Integer;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;ZLjava/lang/Integer;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;ZLjava/lang/Integer;)V
 	public synthetic fun <init> (Ljava/lang/String;ZLjava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;ZLjava/lang/Integer;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;ZLjava/lang/Integer;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Ljava/lang/String;ZLjava/lang/Integer;Ljava/lang/String;Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/lang/String;ZLjava/lang/Integer;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun compareTo (Lapp/morphe/patcher/patch/AppTarget;)I
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Z
-	public final fun component3 ()Ljava/lang/Integer;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Ljava/util/Map;
-	public final fun copy (Ljava/lang/String;ZLjava/lang/Integer;Ljava/lang/String;Ljava/util/Map;)Lapp/morphe/patcher/patch/AppTarget;
-	public static synthetic fun copy$default (Lapp/morphe/patcher/patch/AppTarget;Ljava/lang/String;ZLjava/lang/Integer;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lapp/morphe/patcher/patch/AppTarget;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Z
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/Map;ZLjava/lang/Integer;Ljava/lang/String;)Lapp/morphe/patcher/patch/AppTarget;
+	public static synthetic fun copy$default (Lapp/morphe/patcher/patch/AppTarget;Ljava/lang/String;Ljava/util/Map;ZLjava/lang/Integer;Ljava/lang/String;ILjava/lang/Object;)Lapp/morphe/patcher/patch/AppTarget;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getAppCodes ()Ljava/util/Map;
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getMinSdk ()Ljava/lang/Integer;
 	public final fun getVersion ()Ljava/lang/String;
+	public final fun getVersionCodes ()Ljava/util/Map;
 	public fun hashCode ()I
 	public final fun isExperimental ()Z
 	public fun toString ()Ljava/lang/String;

--- a/api/morphe-patcher.api
+++ b/api/morphe-patcher.api
@@ -538,15 +538,19 @@ public final class app/morphe/patcher/patch/AppTarget : java/lang/Comparable {
 	public synthetic fun <init> (Ljava/lang/String;ZLjava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;ZLjava/lang/Integer;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;ZLjava/lang/Integer;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;ZLjava/lang/Integer;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;ZLjava/lang/Integer;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun compareTo (Lapp/morphe/patcher/patch/AppTarget;)I
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Z
 	public final fun component3 ()Ljava/lang/Integer;
 	public final fun component4 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;ZLjava/lang/Integer;Ljava/lang/String;)Lapp/morphe/patcher/patch/AppTarget;
-	public static synthetic fun copy$default (Lapp/morphe/patcher/patch/AppTarget;Ljava/lang/String;ZLjava/lang/Integer;Ljava/lang/String;ILjava/lang/Object;)Lapp/morphe/patcher/patch/AppTarget;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;ZLjava/lang/Integer;Ljava/lang/String;Ljava/util/Map;)Lapp/morphe/patcher/patch/AppTarget;
+	public static synthetic fun copy$default (Lapp/morphe/patcher/patch/AppTarget;Ljava/lang/String;ZLjava/lang/Integer;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lapp/morphe/patcher/patch/AppTarget;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAppCodes ()Ljava/util/Map;
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getMinSdk ()Ljava/lang/Integer;
 	public final fun getVersion ()Ljava/lang/String;
@@ -881,6 +885,17 @@ public final class app/morphe/patcher/patch/ResourcePatchContext : app/morphe/pa
 	public final fun get (Ljava/lang/String;Z)Ljava/io/File;
 	public static synthetic fun get$default (Lapp/morphe/patcher/patch/ResourcePatchContext;Ljava/lang/String;ZILjava/lang/Object;)Ljava/io/File;
 	public final fun getPackageMetadata ()Lapp/morphe/patcher/PackageMetadata;
+}
+
+public final class app/morphe/patcher/patch/SupportedAbi : java/lang/Enum {
+	public static final field ARM64_V8A Lapp/morphe/patcher/patch/SupportedAbi;
+	public static final field ARMEABI_V7A Lapp/morphe/patcher/patch/SupportedAbi;
+	public static final field UNIVERSAL Lapp/morphe/patcher/patch/SupportedAbi;
+	public static final field X86 Lapp/morphe/patcher/patch/SupportedAbi;
+	public static final field X86_64 Lapp/morphe/patcher/patch/SupportedAbi;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lapp/morphe/patcher/patch/SupportedAbi;
+	public static fun values ()[Lapp/morphe/patcher/patch/SupportedAbi;
 }
 
 public final class app/morphe/patcher/resource/CpuArchitecture : java/lang/Enum {

--- a/api/morphe-patcher.api
+++ b/api/morphe-patcher.api
@@ -892,7 +892,6 @@ public final class app/morphe/patcher/patch/ResourcePatchContext : app/morphe/pa
 public final class app/morphe/patcher/patch/SupportedAbi : java/lang/Enum {
 	public static final field ARM64_V8A Lapp/morphe/patcher/patch/SupportedAbi;
 	public static final field ARMEABI_V7A Lapp/morphe/patcher/patch/SupportedAbi;
-	public static final field UNIVERSAL Lapp/morphe/patcher/patch/SupportedAbi;
 	public static final field X86 Lapp/morphe/patcher/patch/SupportedAbi;
 	public static final field X86_64 Lapp/morphe/patcher/patch/SupportedAbi;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;

--- a/src/main/kotlin/app/morphe/patcher/patch/Compatibility.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/Compatibility.kt
@@ -41,6 +41,17 @@ enum class ApkFileType {
         get() = name.endsWith("_REQUIRED")
 }
 
+enum class SupportedAbi {
+    ARM64_V8A,
+    ARMEABI_V7A,
+    X86_64,
+    X86,
+    UNIVERSAL
+}
+
+typealias AppCode = Int
+
+
 /**
  * Instances are sortable from lowest to highest version, with any version (null) last.
  * Semantic versioning is handled and sorts correctly in situations such as 1.1.0 > 1.0.02
@@ -53,12 +64,14 @@ enum class ApkFileType {
  *   Null means any SDK version.
  * @param description User facing description of the app target, such as why the user may want
  *   to patch this specific app version.
+ *  @param appCodes The recommended app codes //TODO
  */
 data class AppTarget(
     val version: String?,
     val isExperimental: Boolean = false,
     val minSdk: Int? = null,
-    val description: String? = null
+    val description: String? = null,
+    val appCodes: Map<SupportedAbi, AppCode>? = null
 ) : Comparable<AppTarget> {
 
     private val semanticParts: List<Int>? = parseSemantic(version)
@@ -68,7 +81,27 @@ data class AppTarget(
         version: String?,
         isExperimental: Boolean = false,
         minSdk: Int? = null,
-    ) : this(version = version, isExperimental = isExperimental, minSdk = minSdk, description = null)
+    ) : this(
+        version = version,
+        isExperimental = isExperimental,
+        minSdk = minSdk,
+        description = null,
+        appCodes = null
+    )
+
+    // @Deprecated("Here only for binary backwards compatibility") // TODO: Remove after next major version bump.
+    constructor(
+        version: String?,
+        isExperimental: Boolean = false,
+        minSdk: Int? = null,
+        description: String? = null
+    ) : this(
+        version = version,
+        isExperimental = isExperimental,
+        minSdk = minSdk,
+        description = null,
+        appCodes = null
+    )
 
     /**
      * Comparison using only the version field.

--- a/src/main/kotlin/app/morphe/patcher/patch/Compatibility.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/Compatibility.kt
@@ -45,8 +45,7 @@ enum class SupportedAbi {
     ARM64_V8A,
     ARMEABI_V7A,
     X86_64,
-    X86,
-    UNIVERSAL
+    X86
 }
 
 /**

--- a/src/main/kotlin/app/morphe/patcher/patch/Compatibility.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/Compatibility.kt
@@ -65,14 +65,13 @@ enum class SupportedAbi {
  *   Null means any SDK version.
  * @param description User facing description of the app target, such as why the user may want
  *   to patch this specific app version.
-
  */
 data class AppTarget(
     val version: String?,
     val versionCodes: Map<SupportedAbi, Int>? = null,
     val isExperimental: Boolean = false,
     val minSdk: Int? = null,
-    val description: String? = null,
+    val description: String? = null
 ) : Comparable<AppTarget> {
 
     private val semanticParts: List<Int>? = parseSemantic(version)

--- a/src/main/kotlin/app/morphe/patcher/patch/Compatibility.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/Compatibility.kt
@@ -49,9 +49,6 @@ enum class SupportedAbi {
     UNIVERSAL
 }
 
-typealias AppCode = Int
-
-
 /**
  * Instances are sortable from lowest to highest version, with any version (null) last.
  * Semantic versioning is handled and sorts correctly in situations such as 1.1.0 > 1.0.02

--- a/src/main/kotlin/app/morphe/patcher/patch/Compatibility.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/Compatibility.kt
@@ -261,10 +261,7 @@ data class Compatibility(
                 "App icon color must be #RRGGBB format: $color"
             }
 
-            val rgb = color.removePrefix("#").toInt(16)
-
-            // force full opacity
-            return rgb or 0xFF000000.toInt()
+            return color.removePrefix("#").toInt(16)
         }
 
         fun fromLegacy(legacy: Pair<String, Set<String>?>): Compatibility {

--- a/src/main/kotlin/app/morphe/patcher/patch/Compatibility.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/Compatibility.kt
@@ -5,6 +5,10 @@
 
 package app.morphe.patcher.patch
 
+import android.R.attr.versionCode
+import kotlin.collections.all
+import kotlin.collections.isNotEmpty
+
 private val SHA_256_REGEX = Regex("^[0-9a-fA-F]{64}$")
 
 /**
@@ -122,6 +126,12 @@ data class AppTarget(
         minSdk = minSdk,
         description = null
     )
+
+    init {
+        if (version == null && !versionCodes.isNullOrEmpty()) {
+            throw IllegalArgumentException("Version codes requires declaring a version string")
+        }
+    }
 
     /**
      * Comparison using only the version field.

--- a/src/main/kotlin/app/morphe/patcher/patch/Compatibility.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/Compatibility.kt
@@ -56,22 +56,47 @@ enum class SupportedAbi {
  *
  * @param version Version string. Null means any version and additionally can be used to
  *   indicate any version is supported experimentally.
+ *  @param versionCodes Required app version codes. If the map is null, or an architecture
+ *   key value is null, then any app version is assumed to work. This declaration is only required
+ *   for apps that can have multiple releases under the same user facing version string (ie: 5.2.1)
+ *   but only one specific release is supported or recommended. This is common with Meta apps
+ *   but uncommon with most other apps.
  * @param isExperimental If this app target is supported under an experimental capacity.
  * @param minSdk Minimum device SDK version as found in [android.os.Build.VERSION_CODES].
  *   Null means any SDK version.
  * @param description User facing description of the app target, such as why the user may want
  *   to patch this specific app version.
- *  @param appCodes The recommended app codes //TODO
+
  */
 data class AppTarget(
     val version: String?,
+    val versionCodes: Map<SupportedAbi, Int>? = null,
     val isExperimental: Boolean = false,
     val minSdk: Int? = null,
     val description: String? = null,
-    val appCodes: Map<SupportedAbi, AppCode>? = null
 ) : Comparable<AppTarget> {
 
     private val semanticParts: List<Int>? = parseSemantic(version)
+
+    /**
+     * Convenience constructor for a universal APK app target,
+     * where a specific app version is required.
+     *
+     * @param versionCode Specific required app version code.
+     */
+    constructor(
+        version: String,
+        versionCode: Int,
+        isExperimental: Boolean = false,
+        minSdk: Int? = null,
+        description: String? = null,
+    ) : this(
+        version = version,
+        versionCodes = SupportedAbi.entries.associateWith { versionCode },
+        isExperimental = isExperimental,
+        minSdk = minSdk,
+        description = null
+    )
 
     // @Deprecated("Here only for binary backwards compatibility") // TODO: Remove after next major version bump.
     constructor(
@@ -80,10 +105,10 @@ data class AppTarget(
         minSdk: Int? = null,
     ) : this(
         version = version,
+        versionCodes = null,
         isExperimental = isExperimental,
         minSdk = minSdk,
-        description = null,
-        appCodes = null
+        description = null
     )
 
     // @Deprecated("Here only for binary backwards compatibility") // TODO: Remove after next major version bump.
@@ -94,10 +119,10 @@ data class AppTarget(
         description: String? = null
     ) : this(
         version = version,
+        versionCodes = null,
         isExperimental = isExperimental,
         minSdk = minSdk,
-        description = null,
-        appCodes = null
+        description = null
     )
 
     /**

--- a/src/test/kotlin/app/morphe/patcher/patch/CompatibilityTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/patch/CompatibilityTest.kt
@@ -398,7 +398,6 @@ internal object CompatibilityTest {
                 AppTarget(
                     version = "1.0.0", versionCodes = mapOf(
                         SupportedAbi.X86_64 to 100,
-                        SupportedAbi.X86 to 200,
                         SupportedAbi.ARMEABI_V7A to 300,
                         SupportedAbi.ARM64_V8A to 400
                     )
@@ -408,7 +407,10 @@ internal object CompatibilityTest {
 
         var versionCodes = compatibility.targets.first().versionCodes!!
 
-        assertEquals(4, versionCodes.count())
+        assertEquals(3, versionCodes.count())
+        assertEquals(100, versionCodes[SupportedAbi.X86_64])
+        assertEquals(null, versionCodes[SupportedAbi.X86])
+        assertEquals(300, versionCodes[SupportedAbi.ARMEABI_V7A])
         assertEquals(400, versionCodes[SupportedAbi.ARM64_V8A])
 
         // Universal APK

--- a/src/test/kotlin/app/morphe/patcher/patch/CompatibilityTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/patch/CompatibilityTest.kt
@@ -393,6 +393,7 @@ internal object CompatibilityTest {
         var compatibility = Compatibility(
             name = "Example app",
             packageName = "compatible.package",
+            apkFileType = ApkFileType.APKM,
             targets = listOf(
                 AppTarget(
                     version = "1.0.0", versionCodes = mapOf(
@@ -410,9 +411,11 @@ internal object CompatibilityTest {
         assertEquals(4, versionCodes.count())
         assertEquals(400, versionCodes[SupportedAbi.ARM64_V8A])
 
+        // Universal APK
         compatibility = Compatibility(
             name = "Example app",
             packageName = "compatible.package",
+            apkFileType = ApkFileType.APK,
             targets = listOf(
                 AppTarget(version = "1.0.0", versionCode = 500)
             )

--- a/src/test/kotlin/app/morphe/patcher/patch/CompatibilityTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/patch/CompatibilityTest.kt
@@ -5,6 +5,7 @@
 
 package app.morphe.patcher.patch
 
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -439,5 +440,14 @@ internal object CompatibilityTest {
         )
 
         assertEquals(null, compatibility.targets.first().versionCodes)
+
+
+        assertThrows<IllegalArgumentException> {
+            AppTarget(version = null, versionCodes = mapOf(SupportedAbi.ARM64_V8A to 123))
+        }
+
+        assertDoesNotThrow {
+            AppTarget(version = null, versionCodes = mapOf())
+        }
     }
 }

--- a/src/test/kotlin/app/morphe/patcher/patch/CompatibilityTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/patch/CompatibilityTest.kt
@@ -338,4 +338,54 @@ internal object CompatibilityTest {
             sorted
         )
     }
+
+    @Test
+    fun `compatibility color string`() {
+        val colorString = Compatibility(
+            name = "Example app",
+            packageName = "compatible.package",
+            targets = listOf(
+                AppTarget(version = "1.1.0", isExperimental = true),
+                AppTarget(version = "1.0.0", isExperimental = true)
+            ),
+            appIconColor = "#FF0000"
+        )
+
+        val colorInt = Compatibility(
+            name = "Example app",
+            packageName = "compatible.package",
+            targets = listOf(
+                AppTarget(version = "1.1.0", isExperimental = true),
+                AppTarget(version = "1.0.0", isExperimental = true)
+            ),
+            appIconColor = 0xFF0000
+        )
+
+        assertEquals(colorString.appIconColor,  colorInt.appIconColor)
+
+        assertThrows<Exception> {
+            Compatibility(
+                name = "Example app",
+                packageName = "compatible.package",
+                targets = listOf(
+                    AppTarget(version = "1.1.0", isExperimental = true),
+                    AppTarget(version = "1.0.0", isExperimental = true)
+                ),
+                appIconColor = "#00FF0000"
+            )
+        }
+
+        assertThrows<Exception> {
+            Compatibility(
+                name = "Example app",
+                packageName = "compatible.package",
+                targets = listOf(
+                    AppTarget(version = "1.1.0", isExperimental = true),
+                    AppTarget(version = "1.0.0", isExperimental = true)
+                ),
+                appIconColor = "#0000"
+            )
+        }
+    }
+
 }

--- a/src/test/kotlin/app/morphe/patcher/patch/CompatibilityTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/patch/CompatibilityTest.kt
@@ -422,6 +422,7 @@ internal object CompatibilityTest {
         )
         versionCodes = compatibility.targets.first().versionCodes!!
 
+        assertEquals(4, versionCodes.count())
         assertTrue(versionCodes.all { it.value == 500 })
     }
 }

--- a/src/test/kotlin/app/morphe/patcher/patch/CompatibilityTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/patch/CompatibilityTest.kt
@@ -426,5 +426,18 @@ internal object CompatibilityTest {
 
         assertEquals(4, versionCodes.count())
         assertTrue(versionCodes.all { it.value == 500 })
+
+
+        // No version codes
+        compatibility = Compatibility(
+            name = "Example app",
+            packageName = "compatible.package",
+            apkFileType = ApkFileType.APK,
+            targets = listOf(
+                AppTarget(version = "1.0.0")
+            )
+        )
+
+        assertEquals(null, compatibility.targets.first().versionCodes)
     }
 }

--- a/src/test/kotlin/app/morphe/patcher/patch/CompatibilityTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/patch/CompatibilityTest.kt
@@ -388,4 +388,37 @@ internal object CompatibilityTest {
         }
     }
 
+    @Test
+    fun `app version code`() {
+        var compatibility = Compatibility(
+            name = "Example app",
+            packageName = "compatible.package",
+            targets = listOf(
+                AppTarget(
+                    version = "1.0.0", versionCodes = mapOf(
+                        SupportedAbi.X86_64 to 100,
+                        SupportedAbi.X86 to 200,
+                        SupportedAbi.ARMEABI_V7A to 300,
+                        SupportedAbi.ARM64_V8A to 400
+                    )
+                )
+            )
+        )
+
+        var versionCodes = compatibility.targets.first().versionCodes!!
+
+        assertEquals(4, versionCodes.count())
+        assertEquals(400, versionCodes[SupportedAbi.ARM64_V8A])
+
+        compatibility = Compatibility(
+            name = "Example app",
+            packageName = "compatible.package",
+            targets = listOf(
+                AppTarget(version = "1.0.0", versionCode = 500)
+            )
+        )
+        versionCodes = compatibility.targets.first().versionCodes!!
+
+        assertTrue(versionCodes.all { it.value == 500 })
+    }
 }


### PR DESCRIPTION
Because Meta loves to make multiple releases with the same user facing version string but different version codes, and some of these releases are very different from each other, compatibility can now be restricted to specific version codes that are known to work or are well tested.

This is required only when a user facing version string is ambiguous of which APK/APKM is recommended.

For example, to restrict Instagram `425.0.0.47.6` to only known and tested 120-640dpi releases:
https://www.apkmirror.com/apk/instagram/instagram-instagram/instagram-425-0-0-47-61-release/

```
Compatibility(
    name = "Instagram",
    packageName = "com.instagram.android",
    apkFileType = ApkFileType.APKM,
    targets = listOf(
        AppTarget(
            version = "425.0.0.47.6",
            versionCodes = mapOf(
                ARMEABI_V7A to 383105984,
                ARM64_V8A to 383105966,
                X86 to 383105986,
                X86_64 to 383105966,
            )
        )
    )
)
```

Eventually Morphe Manager will warn if the user provided APK/APKM has a version code that is not one of these recommended version.