### PR TITLE
feat: Instruction match helper methods to get a called method or accessed field

### DIFF
--- a/api/morphe-patcher.api
+++ b/api/morphe-patcher.api
@@ -226,12 +226,12 @@ public final class app/morphe/patcher/Match {
 }
 
 public final class app/morphe/patcher/Match$InstructionMatch {
-	public final fun getAccessedField (Lapp/morphe/patcher/patch/BytecodePatchContext;)Lapp/morphe/patcher/util/proxy/mutableTypes/MutableField;
-	public final fun getCalledMethod (Lapp/morphe/patcher/patch/BytecodePatchContext;)Lapp/morphe/patcher/util/proxy/mutableTypes/MutableMethod;
+	public final fun getFieldAccessed (Lapp/morphe/patcher/patch/BytecodePatchContext;)Lapp/morphe/patcher/util/proxy/mutableTypes/MutableField;
 	public final fun getFilter ()Lapp/morphe/patcher/InstructionFilter;
 	public final fun getIndex ()I
 	public final fun getInstruction ()Lcom/android/tools/smali/dexlib2/iface/instruction/Instruction;
 	public final fun getInstruction ()Ljava/lang/Object;
+	public final fun getMethodCalled (Lapp/morphe/patcher/patch/BytecodePatchContext;)Lapp/morphe/patcher/util/proxy/mutableTypes/MutableMethod;
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/api/morphe-patcher.api
+++ b/api/morphe-patcher.api
@@ -226,12 +226,12 @@ public final class app/morphe/patcher/Match {
 }
 
 public final class app/morphe/patcher/Match$InstructionMatch {
-	public final fun getFieldAccess (Lapp/morphe/patcher/patch/BytecodePatchContext;)Lapp/morphe/patcher/util/proxy/mutableTypes/MutableField;
+	public final fun getAccessedField (Lapp/morphe/patcher/patch/BytecodePatchContext;)Lapp/morphe/patcher/util/proxy/mutableTypes/MutableField;
+	public final fun getCalledMethod (Lapp/morphe/patcher/patch/BytecodePatchContext;)Lapp/morphe/patcher/util/proxy/mutableTypes/MutableMethod;
 	public final fun getFilter ()Lapp/morphe/patcher/InstructionFilter;
 	public final fun getIndex ()I
 	public final fun getInstruction ()Lcom/android/tools/smali/dexlib2/iface/instruction/Instruction;
 	public final fun getInstruction ()Ljava/lang/Object;
-	public final fun getMethodCall (Lapp/morphe/patcher/patch/BytecodePatchContext;)Lapp/morphe/patcher/util/proxy/mutableTypes/MutableMethod;
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/api/morphe-patcher.api
+++ b/api/morphe-patcher.api
@@ -226,10 +226,12 @@ public final class app/morphe/patcher/Match {
 }
 
 public final class app/morphe/patcher/Match$InstructionMatch {
+	public final fun getFieldAccess (Lapp/morphe/patcher/patch/BytecodePatchContext;)Lapp/morphe/patcher/util/proxy/mutableTypes/MutableField;
 	public final fun getFilter ()Lapp/morphe/patcher/InstructionFilter;
 	public final fun getIndex ()I
 	public final fun getInstruction ()Lcom/android/tools/smali/dexlib2/iface/instruction/Instruction;
 	public final fun getInstruction ()Ljava/lang/Object;
+	public final fun getMethodCall (Lapp/morphe/patcher/patch/BytecodePatchContext;)Lapp/morphe/patcher/util/proxy/mutableTypes/MutableMethod;
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/src/main/kotlin/app/morphe/patcher/Fingerprint.kt
+++ b/src/main/kotlin/app/morphe/patcher/Fingerprint.kt
@@ -14,15 +14,21 @@ import app.morphe.patcher.extensions.InstructionExtensions.instructionsOrNull
 import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.util.PatchClasses
+import app.morphe.patcher.util.proxy.mutableTypes.MutableField
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.ClassDef
 import com.android.tools.smali.dexlib2.iface.Method
 import com.android.tools.smali.dexlib2.iface.instruction.Instruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.iface.reference.StringReference
 import com.android.tools.smali.dexlib2.util.MethodUtil
 import java.lang.ref.WeakReference
+import kotlin.collections.forEachIndexed
+import kotlin.collections.indexOfFirst
 
 open class Fingerprint private constructor(
     val classFingerprint: Fingerprint? = null,
@@ -942,6 +948,43 @@ class Match internal constructor(
          */
         @Suppress("UNCHECKED_CAST")
         fun <T> getInstruction(): T = instruction as T
+
+        /**
+         * Returns the mutable method of a method call instruction.
+         * This may only be used on filters that match method calls such as [methodCall]
+         * or [opcode] with an `INVOKE` [Opcode].
+         */
+        context(BytecodePatchContext)
+        val methodCall: MutableMethod
+            get() {
+                require(instruction is ReferenceInstruction && instruction.reference is MethodReference) {
+                    "Matched instruction is not a method call: $instruction"
+                }
+
+                val methodReference = instruction.reference as MethodReference
+                return mutableClassDefBy(methodReference.definingClass).methods.first { classMethod ->
+                    MethodUtil.methodSignaturesMatch(classMethod, methodReference)
+                }
+            }
+
+        /**
+         * Returns the mutable method of a field access instruction.
+         * This may only be used on filters that match method calls such as [fieldAccess]
+         * or [opcode] with an `_GET`/`_PUT` [Opcode].
+         */
+        context(BytecodePatchContext)
+        val fieldAccess: MutableField
+            get() {
+                require(instruction is ReferenceInstruction && instruction.reference is FieldReference) {
+                    "Matched instruction is not a a field access call: $instruction"
+                }
+
+                val fieldReference = instruction.reference as FieldReference
+                val mutableClass = mutableClassDefBy(fieldReference.definingClass)
+                return mutableClass.fields.first { classField ->
+                    classField.type == fieldReference.type && classField.name == fieldReference.name
+                }
+            }
 
         override fun toString(): String {
             return "InstructionMatch{filter='${filter.javaClass.simpleName}, opcode='${instruction.opcode}, 'index=$index}"

--- a/src/main/kotlin/app/morphe/patcher/Fingerprint.kt
+++ b/src/main/kotlin/app/morphe/patcher/Fingerprint.kt
@@ -955,7 +955,7 @@ class Match internal constructor(
          * or [opcode] with an `INVOKE_*` [Opcode].
          */
         context(BytecodePatchContext)
-        fun getCalledMethod(): MutableMethod {
+        fun getMethodCalled(): MutableMethod {
             require(instruction is ReferenceInstruction && instruction.reference is MethodReference) {
                 "Matched instruction is not a method call: $instruction"
             }
@@ -972,7 +972,7 @@ class Match internal constructor(
          * or [opcode] with a `GET`/`PUT` [Opcode].
          */
         context(BytecodePatchContext)
-        fun getAccessedField(): MutableField {
+        fun getFieldAccessed(): MutableField {
             require(instruction is ReferenceInstruction && instruction.reference is FieldReference) {
                 "Matched instruction is not a a field access call: $instruction"
             }

--- a/src/main/kotlin/app/morphe/patcher/Fingerprint.kt
+++ b/src/main/kotlin/app/morphe/patcher/Fingerprint.kt
@@ -952,39 +952,37 @@ class Match internal constructor(
         /**
          * Returns the mutable method of a method call instruction.
          * This may only be used on filters that match method calls such as [methodCall]
-         * or [opcode] with an `INVOKE` [Opcode].
+         * or [opcode] with an `INVOKE_*` [Opcode].
          */
         context(BytecodePatchContext)
-        val methodCall: MutableMethod
-            get() {
-                require(instruction is ReferenceInstruction && instruction.reference is MethodReference) {
-                    "Matched instruction is not a method call: $instruction"
-                }
-
-                val methodReference = instruction.reference as MethodReference
-                return mutableClassDefBy(methodReference.definingClass).methods.first { classMethod ->
-                    MethodUtil.methodSignaturesMatch(classMethod, methodReference)
-                }
+        fun getCalledMethod(): MutableMethod {
+            require(instruction is ReferenceInstruction && instruction.reference is MethodReference) {
+                "Matched instruction is not a method call: $instruction"
             }
+
+            val methodReference = instruction.reference as MethodReference
+            return mutableClassDefBy(methodReference.definingClass).methods.first { classMethod ->
+                MethodUtil.methodSignaturesMatch(classMethod, methodReference)
+            }
+        }
 
         /**
          * Returns the mutable method of a field access instruction.
          * This may only be used on filters that match method calls such as [fieldAccess]
-         * or [opcode] with an `_GET`/`_PUT` [Opcode].
+         * or [opcode] with a `GET`/`PUT` [Opcode].
          */
         context(BytecodePatchContext)
-        val fieldAccess: MutableField
-            get() {
-                require(instruction is ReferenceInstruction && instruction.reference is FieldReference) {
-                    "Matched instruction is not a a field access call: $instruction"
-                }
-
-                val fieldReference = instruction.reference as FieldReference
-                val mutableClass = mutableClassDefBy(fieldReference.definingClass)
-                return mutableClass.fields.first { classField ->
-                    classField.type == fieldReference.type && classField.name == fieldReference.name
-                }
+        fun getAccessedField(): MutableField {
+            require(instruction is ReferenceInstruction && instruction.reference is FieldReference) {
+                "Matched instruction is not a a field access call: $instruction"
             }
+
+            val fieldReference = instruction.reference as FieldReference
+            val mutableClass = mutableClassDefBy(fieldReference.definingClass)
+            return mutableClass.fields.first { classField ->
+                classField.type == fieldReference.type && classField.name == fieldReference.name
+            }
+        }
 
         override fun toString(): String {
             return "InstructionMatch{filter='${filter.javaClass.simpleName}, opcode='${instruction.opcode}, 'index=$index}"

--- a/src/main/kotlin/app/morphe/patcher/patch/BytecodePatchContext.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/BytecodePatchContext.kt
@@ -242,6 +242,8 @@ class BytecodePatchContext internal constructor(private val config: PatcherConfi
      *
      * @return A [MethodNavigator] for the method.
      */
+    @Deprecated("Instead use Fingerprint instruction match `methodCall` field," +
+            " or lookup a method from an index using BytecodeUtils MethodReference.getMutableMethod()")
     fun navigate(method: MethodReference) = MethodNavigator(method)
 
     /**

--- a/src/main/kotlin/app/morphe/patcher/patch/BytecodePatchContext.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/BytecodePatchContext.kt
@@ -242,7 +242,7 @@ class BytecodePatchContext internal constructor(private val config: PatcherConfi
      *
      * @return A [MethodNavigator] for the method.
      */
-    @Deprecated("Instead use Fingerprint instruction match `methodCall` field," +
+    @Deprecated("Instead use Fingerprint instruction match `getMethodCalled()`," +
             " or lookup a method from an index using BytecodeUtils MethodReference.getMutableMethod()")
     fun navigate(method: MethodReference) = MethodNavigator(method)
 

--- a/src/main/kotlin/app/morphe/patcher/util/MethodNavigator.kt
+++ b/src/main/kotlin/app/morphe/patcher/util/MethodNavigator.kt
@@ -23,6 +23,8 @@ import kotlin.reflect.KProperty
  * @throws NavigateException If the method does not have an implementation.
  * @throws NavigateException If the instruction at the specified index is not a method reference.
  */
+@Deprecated("Instead use Fingerprint instruction match `methodCall` field," +
+        " or lookup a method from an index using BytecodeUtils MethodReference.getMutableMethod()")
 context(BytecodePatchContext)
 class MethodNavigator internal constructor(
     private var startMethod: MethodReference,

--- a/src/main/kotlin/app/morphe/patcher/util/MethodNavigator.kt
+++ b/src/main/kotlin/app/morphe/patcher/util/MethodNavigator.kt
@@ -23,7 +23,7 @@ import kotlin.reflect.KProperty
  * @throws NavigateException If the method does not have an implementation.
  * @throws NavigateException If the instruction at the specified index is not a method reference.
  */
-@Deprecated("Instead use Fingerprint instruction match `methodCall` field," +
+@Deprecated("Instead use Fingerprint instruction match `getMethodCalled()`," +
         " or lookup a method from an index using BytecodeUtils MethodReference.getMutableMethod()")
 context(BytecodePatchContext)
 class MethodNavigator internal constructor(


### PR DESCRIPTION
Adds simple helper methods to simplify getting a mutable method/field from an instruction match.

```
internal object AllowControversialContentFingerprint : Fingerprint(
    returnType = "V",
    parameters = listOf("L"),
    filters = listOf(
        string("Whatever"),
        methodCall(
            name = "hasElements",
            parameters = listOf(),
            returnType = "Z",
            location = MatchAfterWithin(4)
        ),
        fieldAccess(
            name = "elements",
            type = "Ljava/util/ArrayList;"
        )
    )
)
```

Before:
```
AllowControversialContentFingerprint.apply {
    // hasElements method
    val allowControversialContentMethod = instructionMatches[1]
        .getInstruction<ReferenceInstruction>()
        .getReference<MethodReference>()!!
        .getMutableMethod()

    // elements field
    val field = instructionMatches[2].instruction.getReference<FieldReference>()!!
}
```

After:
```
AllowControversialContentFingerprint.apply {
    // hasElements method
    val allowControversialContentMethod = instructionMatches[1].getMethodCalled()

    // elements field
    val field = instructionMatches[2].getFieldAccessed()
}
```