### PR TITLE
feat: `Compatibility` `including()` and `excluding()` methods

### DIFF
--- a/api/morphe-patcher.api
+++ b/api/morphe-patcher.api
@@ -607,6 +607,7 @@ public final class app/morphe/patcher/patch/Compatibility {
 	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lapp/morphe/patcher/patch/ApkFileType;Ljava/lang/Integer;Ljava/util/Set;Ljava/util/List;)Lapp/morphe/patcher/patch/Compatibility;
 	public static synthetic fun copy$default (Lapp/morphe/patcher/patch/Compatibility;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lapp/morphe/patcher/patch/ApkFileType;Ljava/lang/Integer;Ljava/util/Set;Ljava/util/List;ILjava/lang/Object;)Lapp/morphe/patcher/patch/Compatibility;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun excluding ([Ljava/lang/String;)Lapp/morphe/patcher/patch/Compatibility;
 	public final fun getApkFileType ()Lapp/morphe/patcher/patch/ApkFileType;
 	public final fun getAppIconColor ()Ljava/lang/Integer;
 	public final fun getDescription ()Ljava/lang/String;
@@ -615,6 +616,7 @@ public final class app/morphe/patcher/patch/Compatibility {
 	public final fun getSignatures ()Ljava/util/Set;
 	public final fun getTargets ()Ljava/util/List;
 	public fun hashCode ()I
+	public final fun including ([Lapp/morphe/patcher/patch/AppTarget;)Lapp/morphe/patcher/patch/Compatibility;
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/src/main/kotlin/app/morphe/patcher/patch/Compatibility.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/Compatibility.kt
@@ -222,6 +222,26 @@ data class Compatibility(
         packageName to legacyStringTargets
     }
 
+    /**
+     * This [Compatibility] but with additional [AppTarget] versions.
+     */
+    fun including(vararg targets: AppTarget): Compatibility {
+        return copy(targets = this.targets + targets)
+    }
+
+    /**
+     * This [Compatibility] but excluding all app targets with the
+     * specified [AppTarget.version] version strings.
+     */
+    fun excluding(vararg versions: String): Compatibility {
+        val versionSet = versions.toSet()
+        val updatedTargets = targets
+            .filter { it.version !in versionSet }
+            .ifEmpty { listOf(AppTarget(version = null)) }
+
+        return copy(targets = updatedTargets)
+    }
+
     internal companion object {
         private fun parseColor(color: String): Int {
             require(color.startsWith('#') && color.length == 7) {

--- a/src/main/kotlin/app/morphe/patcher/patch/Compatibility.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/Compatibility.kt
@@ -226,7 +226,7 @@ data class Compatibility(
      * This [Compatibility] but with additional [AppTarget] versions.
      */
     fun including(vararg targets: AppTarget): Compatibility {
-        return copy(targets = this.targets + targets)
+        return copy(targets = (this.targets + targets).sortedDescending())
     }
 
     /**

--- a/src/main/kotlin/app/morphe/patcher/patch/Compatibility.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/Compatibility.kt
@@ -233,7 +233,7 @@ data class Compatibility(
      * This [Compatibility] but excluding all app targets with the
      * specified [AppTarget.version] version strings.
      */
-    fun excluding(vararg versions: String): Compatibility {
+    fun excluding(vararg versions: String?): Compatibility {
         val versionSet = versions.toSet()
         val updatedTargets = targets
             .filter { it.version !in versionSet }

--- a/src/test/kotlin/app/morphe/patcher/patch/CompatibilityTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/patch/CompatibilityTest.kt
@@ -193,8 +193,8 @@ internal object CompatibilityTest {
             name = "Example app",
             packageName = "compatible.package",
             targets = listOf(
-                AppTarget(version = "1.0.0"),
-                AppTarget(version = "2.0.0")
+                AppTarget(version = "2.0.0"),
+                AppTarget(version = "1.0.0")
             )
         )
 
@@ -203,8 +203,8 @@ internal object CompatibilityTest {
             packageName = "compatible.package",
             targets = listOf(
                 AppTarget(version = null),
-                AppTarget(version = "1.0.0"),
-                AppTarget(version = "2.0.0")
+                AppTarget(version = "2.0.0"),
+                AppTarget(version = "1.0.0")
             )
         )
 
@@ -217,8 +217,8 @@ internal object CompatibilityTest {
         assertNotEquals(version1_2, version_any)
 
         assertEquals(
+            version1_2,
             version_1.including(AppTarget(version = "2.0.0")),
-            version1_2
         )
 
         assertEquals(
@@ -232,18 +232,31 @@ internal object CompatibilityTest {
         )
 
         assertEquals(
+            version_any,
             version1_2.excluding("1.0.0", "2.0.0"),
-            version_any
         )
 
         assertEquals(
+            version_any,
             version1_2_any.excluding("1.0.0", "2.0.0"),
-            version_any
         )
 
         assertEquals(
-            version1_2_any.excluding(null, "2.0.0"),
-            version_1
+            version_1,
+            version1_2_any.excluding(null, "2.0.0")
+        )
+
+        assertEquals(
+            listOf(
+                AppTarget(version = null),
+                AppTarget(version = "2.0.0"),
+                AppTarget(version = "1.5.0"),
+                AppTarget(version = "1.0.0"),
+            ),
+            version1_2.including(
+                AppTarget(version = "1.5.0"),
+                AppTarget(version = null)
+            ).targets
         )
     }
 

--- a/src/test/kotlin/app/morphe/patcher/patch/CompatibilityTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/patch/CompatibilityTest.kt
@@ -180,7 +180,7 @@ internal object CompatibilityTest {
     }
 
     @Test
-    fun `including`() {
+    fun `including excluding`() {
         val version_1 = Compatibility(
             name = "Example app",
             packageName = "compatible.package",
@@ -193,6 +193,16 @@ internal object CompatibilityTest {
             name = "Example app",
             packageName = "compatible.package",
             targets = listOf(
+                AppTarget(version = "1.0.0"),
+                AppTarget(version = "2.0.0")
+            )
+        )
+
+        val version1_2_any = Compatibility(
+            name = "Example app",
+            packageName = "compatible.package",
+            targets = listOf(
+                AppTarget(version = null),
                 AppTarget(version = "1.0.0"),
                 AppTarget(version = "2.0.0")
             )
@@ -224,6 +234,16 @@ internal object CompatibilityTest {
         assertEquals(
             version1_2.excluding("1.0.0", "2.0.0"),
             version_any
+        )
+
+        assertEquals(
+            version1_2_any.excluding("1.0.0", "2.0.0"),
+            version_any
+        )
+
+        assertEquals(
+            version1_2_any.excluding(null, "2.0.0"),
+            version_1
         )
     }
 

--- a/src/test/kotlin/app/morphe/patcher/patch/CompatibilityTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/patch/CompatibilityTest.kt
@@ -8,6 +8,7 @@ package app.morphe.patcher.patch
 import org.junit.jupiter.api.assertThrows
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
 internal object CompatibilityTest {
@@ -47,7 +48,7 @@ internal object CompatibilityTest {
         )
 
         var compatibility = Compatibility(
-            name ="Example app",
+            name = "Example app",
             packageName = "compatible.package",
             targets = listOf(
                 AppTarget(version = null),
@@ -58,7 +59,7 @@ internal object CompatibilityTest {
         assertEquals(null, compatibility.legacy!!.second)
 
         compatibility = Compatibility(
-            name ="Example app",
+            name = "Example app",
             packageName = "compatible.package",
             targets = listOf(
                 AppTarget(version = null, isExperimental = true),
@@ -88,7 +89,7 @@ internal object CompatibilityTest {
     @Test
     fun `legacy experimental declaration`() {
         val compatibility = Compatibility(
-            name ="Example app",
+            name = "Example app",
             packageName = "compatible.package",
             targets = listOf(
                 AppTarget(version = "1.1.0", isExperimental = true),
@@ -126,7 +127,7 @@ internal object CompatibilityTest {
     @Test
     fun `universal app`() {
         var compatibility = Compatibility(
-            name ="Example app",
+            name = "Example app",
             targets = listOf(AppTarget(version = null, minSdk = 26))
         )
 
@@ -146,7 +147,7 @@ internal object CompatibilityTest {
     fun `duplicate versions`() {
         assertThrows<Exception> {
             Compatibility(
-                name ="Example app",
+                name = "Example app",
                 packageName = "compatible.package",
                 targets = listOf(
                     AppTarget(version = "1.0.0"),
@@ -157,7 +158,7 @@ internal object CompatibilityTest {
 
         assertThrows<Exception> {
             Compatibility(
-                name ="Example app",
+                name = "Example app",
                 packageName = "compatible.package",
                 targets = listOf(
                     AppTarget(version = "1.0.0", isExperimental = true),
@@ -168,7 +169,7 @@ internal object CompatibilityTest {
 
         assertThrows<Exception> {
             Compatibility(
-                name ="Example app",
+                name = "Example app",
                 packageName = "compatible.package",
                 targets = listOf(
                     AppTarget(version = null, isExperimental = true),
@@ -176,6 +177,54 @@ internal object CompatibilityTest {
                 )
             )
         }
+    }
+
+    @Test
+    fun `including`() {
+        val version_1 = Compatibility(
+            name = "Example app",
+            packageName = "compatible.package",
+            targets = listOf(
+                AppTarget(version = "1.0.0")
+            )
+        )
+
+        val version1_2 = Compatibility(
+            name = "Example app",
+            packageName = "compatible.package",
+            targets = listOf(
+                AppTarget(version = "1.0.0"),
+                AppTarget(version = "2.0.0")
+            )
+        )
+
+        val version_any = Compatibility(
+            name = "Example app",
+            packageName = "compatible.package",
+        )
+
+        assertNotEquals(version_1, version1_2)
+        assertNotEquals(version1_2, version_any)
+
+        assertEquals(
+            version_1.including(AppTarget(version = "2.0.0")),
+            version1_2
+        )
+
+        assertEquals(
+            version_1,
+            version1_2.excluding("2.0.0"),
+        )
+
+        assertEquals(
+            version1_2,
+            version1_2.excluding("non-existent-version"),
+        )
+
+        assertEquals(
+            version1_2.excluding("1.0.0", "2.0.0"),
+            version_any
+        )
     }
 
     @Test


### PR DESCRIPTION
Adds helper methods to add or remove app targets to an existing Compatibility declaration.

```
val COMPATIBILITY_XYZ = Compatibility(
    name = "XYZ app",
    packageName = "app.xyz.whatever",
    targets = listOf(
        AppTarget(version = "2.0.0"),
        AppTarget(version = "1.0.0")
    )
)

// Only 1.0.0
val versions_1 = COMPATIBILITY_XYZ.excluding("2.0.0")

// 1.0.0, 2.0.0, 3.0.0
val versions_1_2_3 = COMPATIBILITY_XYZ.including(AppTarget(version = "3.0.0"))

// 1.0.0, 2.0.0, and 'any' experimental support
val versions_1_2_3 = COMPATIBILITY_XYZ.including(AppTarget(version = null, isExperimental = true))

```

If all versions are removed then the Compatibility becomes 'any version' with a single AppTarget with a null version string.