### PR TITLE
fix: loadPatchesFromDex fails on Android 8.0 if optimizedDexDirectory is null

### DIFF
--- a/api/morphe-patcher.api
+++ b/api/morphe-patcher.api
@@ -808,8 +808,7 @@ public final class app/morphe/patcher/patch/PatchException : java/lang/Exception
 public final class app/morphe/patcher/patch/PatchKt {
 	public static final fun bytecodePatch (Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Lapp/morphe/patcher/patch/BytecodePatch;
 	public static synthetic fun bytecodePatch$default (Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lapp/morphe/patcher/patch/BytecodePatch;
-	public static final fun loadPatchesFromDex (Ljava/util/Set;Ljava/io/File;)Lapp/morphe/patcher/patch/PatchLoader$Dex;
-	public static synthetic fun loadPatchesFromDex$default (Ljava/util/Set;Ljava/io/File;ILjava/lang/Object;)Lapp/morphe/patcher/patch/PatchLoader$Dex;
+	public static final fun loadPatchesFromDex (Ljava/util/Set;)Lapp/morphe/patcher/patch/PatchLoader$Dex;
 	public static final fun loadPatchesFromJar (Ljava/util/Set;)Lapp/morphe/patcher/patch/PatchLoader$Jar;
 	public static final fun rawResourcePatch (Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Lapp/morphe/patcher/patch/RawResourcePatch;
 	public static synthetic fun rawResourcePatch$default (Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lapp/morphe/patcher/patch/RawResourcePatch;
@@ -840,8 +839,7 @@ public abstract class app/morphe/patcher/patch/PatchLoader : java/util/Set, kotl
 }
 
 public final class app/morphe/patcher/patch/PatchLoader$Dex : app/morphe/patcher/patch/PatchLoader {
-	public fun <init> (Ljava/util/Set;Ljava/io/File;)V
-	public synthetic fun <init> (Ljava/util/Set;Ljava/io/File;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/Set;)V
 }
 
 public final class app/morphe/patcher/patch/PatchLoader$Jar : app/morphe/patcher/patch/PatchLoader {

--- a/src/main/kotlin/app/morphe/patcher/patch/Patch.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/Patch.kt
@@ -5,7 +5,7 @@ package app.morphe.patcher.patch
 import app.morphe.patcher.Patcher
 import app.morphe.patcher.PatcherContext
 import app.morphe.patcher.dex.DexReadWrite
-import dalvik.system.DexClassLoader
+import dalvik.system.PathClassLoader
 import java.io.File
 import java.io.InputStream
 import java.lang.reflect.Member
@@ -756,12 +756,10 @@ sealed class PatchLoader(
      * A [PatchLoader] for [Dex] files.
      *
      * @param patchesFiles The DEX files to load the patches from.
-     * @param optimizedDexDirectory The directory to store optimized DEX files in.
-     * This parameter is deprecated and has no effect since API level 26.
      *
      * @constructor Create a new [PatchLoader] for [Dex] files.
      */
-    class Dex(patchesFiles: Set<File>, optimizedDexDirectory: File? = null) :
+    class Dex(patchesFiles: Set<File>) :
         PatchLoader(
             patchesFiles,
             { patchBundle ->
@@ -772,10 +770,8 @@ sealed class PatchLoader(
                         classDef.type.substring(1, classDef.length - 1)
                     }
             },
-            DexClassLoader(
+            PathClassLoader(
                 patchesFiles.joinToString(File.pathSeparator) { it.absolutePath },
-                optimizedDexDirectory?.absolutePath,
-                null,
                 this::class.java.classLoader,
             ),
         )
@@ -853,5 +849,5 @@ fun loadPatchesFromJar(patchesFiles: Set<File>) =
  *
  * @return The loaded patches.
  */
-fun loadPatchesFromDex(patchesFiles: Set<File>, optimizedDexDirectory: File? = null) =
-    PatchLoader.Dex(patchesFiles, optimizedDexDirectory)
+fun loadPatchesFromDex(patchesFiles: Set<File>) =
+    PatchLoader.Dex(patchesFiles)


### PR DESCRIPTION
Fixes https://github.com/MorpheApp/morphe-manager/issues/124

Same change as https://github.com/ReVanced/revanced-patcher/commit/f4b65f53447356e9ba186c0515da8c1bc1db92d1

There is an issue in `DexClassLoader`.
https://developer.android.com/reference/dalvik/system/DexClassLoader
The `optimizedDirectory` parameter is supposed to has no effect since API level 26, but it can't be null only on API level 26.
However, in the `loadPatchesFromDex` function that wraps it, this was declared as nullable.
And because Morphe Manager was passing null to it, a NullPointerException always occurred on Android 8.0.

This PR changes DexClassLoader with `PathClassLoader`.
Both use a common internal implementation in Android 8.0 and later. The only difference is that there is no the problematic optimizedDirectory parameter.

As a side note, this can also be fixed by passing `Context.getCodeCacheDir()` to optimizedDirectory parameter on the Morphe Manager side ([here](https://github.com/MorpheApp/morphe-manager/blob/05709a4dabee2c292ac84c20d8ae6b332c6edcbf/app/src/main/java/app/morphe/manager/patcher/patch/PatchBundle.kt#L62)).
But using PathClassLoader is the better solution because the parameter doesn't exist in the first place, while the internal implementation is the same.

This will also change the API, but since the Manager doesn't pass this parameter already, simply bumping the patcher version and rebuild will suffice.

Furthermore, when bumping the Manager's patcher version to a version that includes this fix, please consider including a news that the issue in Android 8.0 has been fixed in the release notes for end users by using a commit message like `fix: Fix patches aren't loaded on Android 8.0 by updating patcher dependency`
This allows Android 8.0 users who had previously given up on using Manager to notice the fix.