### PR TITLE
fix: Release memory mapped file handles on Windows

### DIFF
--- a/api/morphe-patcher.api
+++ b/api/morphe-patcher.api
@@ -407,6 +407,11 @@ public final class app/morphe/patcher/dex/BytecodeMode : java/lang/Enum {
 	public static fun values ()[Lapp/morphe/patcher/dex/BytecodeMode;
 }
 
+public final class app/morphe/patcher/dex/DexUtils {
+	public static final field INSTANCE Lapp/morphe/patcher/dex/DexUtils;
+	public final fun unsafeUnmap (Ljava/nio/MappedByteBuffer;)V
+}
+
 public final class app/morphe/patcher/dex/DexVerificationException : java/lang/RuntimeException {
 	public fun <init> (Ljava/lang/String;)V
 }
@@ -439,6 +444,7 @@ public final class app/morphe/patcher/dex/SdkDexVerifier$Companion {
 public final class app/morphe/patcher/environment/EnvironmentUtils {
 	public static final field INSTANCE Lapp/morphe/patcher/environment/EnvironmentUtils;
 	public final fun isAndroidEnvironment ()Z
+	public final fun isWindowsEnvironment ()Z
 }
 
 public final class app/morphe/patcher/extensions/ExtensionsKt {

--- a/src/main/kotlin/app/morphe/patcher/dex/DexReadWrite.kt
+++ b/src/main/kotlin/app/morphe/patcher/dex/DexReadWrite.kt
@@ -48,20 +48,6 @@ import kotlin.collections.zip
 import kotlin.math.max
 import kotlin.math.min
 
-/**
- * The result of reading a multidex file, containing both the merged [DexFile] view
- * and the names of each individual DEX entry within the container.
- *
- * @param dexFile A merged [DexFile] containing all classes from all DEX entries.
- * @param extractedDexFiles The names of each original DEX entry (e.g., "classes.dex", "classes2.dex").
- * @param classDescriptorsByEntry Maps each DEX entry name to the set of class descriptors it contains.
- */
-internal class MultidexReadResult(
-    val dexFile: DexFile,
-    val extractedDexFiles: List<File>,
-    val classDescriptorsByEntry: Map<String, Set<String>>,
-)
-
 internal object DexReadWrite {
     private const val MIN_CLASSES_PER_SEGMENT = 1000
     private const val MAX_THREADS = 4
@@ -85,33 +71,7 @@ internal object DexReadWrite {
         val extractedFiles = extractDexEntries(inputFile, outputDir)
         logger?.info("Loaded multidex file: $inputFile with ${extractedFiles.size} dex files")
 
-        val memoryMappedDexFiles = extractedFiles.map { file ->
-            val rwFile = RandomAccessFile(file, "rw")
-            val mappedByteBuffer = rwFile.channel.map(FileChannel.MapMode.READ_WRITE, 0, rwFile.channel.size())
-            DexBackedDexFile(null, mappedByteBuffer)
-        }
-        val entryNames = extractedFiles.map { file -> file.name }
-
-        // Track which class descriptors belong to which DEX entry.
-        val classDescriptorsByEntry = entryNames.zip(memoryMappedDexFiles).associate { (name, dex) ->
-            name to dex.classes.let { classes ->
-                classes.mapTo(HashSet(2 * classes.size)) { it.type }
-            }
-        }
-
-        val opcodes = memoryMappedDexFiles.maxByOrNull { it.opcodes.api }!!.opcodes
-
-        val mergedDexFile = object : DexFile {
-            override fun getClasses(): Set<ClassDef> {
-                return memoryMappedDexFiles.flatMap { it.classes }.toSet()
-            }
-
-            override fun getOpcodes(): Opcodes {
-                return opcodes
-            }
-        }
-
-        return MultidexReadResult(mergedDexFile, extractedFiles, classDescriptorsByEntry)
+        return MultidexReadResult(extractedFiles)
     }
 
     /**

--- a/src/main/kotlin/app/morphe/patcher/dex/DexStripper.kt
+++ b/src/main/kotlin/app/morphe/patcher/dex/DexStripper.kt
@@ -5,10 +5,12 @@
 
 package app.morphe.patcher.dex
 
+import app.morphe.patcher.environment.EnvironmentUtils
 import java.io.File
 import java.io.RandomAccessFile
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
+import java.nio.MappedByteBuffer
 import java.nio.channels.FileChannel
 import java.security.MessageDigest
 import java.util.zip.Adler32
@@ -64,9 +66,11 @@ internal object DexStripper {
     fun stripInPlace(dexFile: File, classDescriptorsToStrip: Set<String>): Int {
         if (classDescriptorsToStrip.isEmpty()) return 0
 
-        RandomAccessFile(dexFile, "rw").use { raf ->
+        val raf = RandomAccessFile(dexFile, "rw")
+        var mappedBuf: MappedByteBuffer? = null
+        try {
             val fileSize = raf.length().toInt()
-            val mappedBuf = raf.channel.map(FileChannel.MapMode.READ_WRITE, 0, raf.length())
+            mappedBuf = raf.channel.map(FileChannel.MapMode.READ_WRITE, 0, raf.length())
             val buf = mappedBuf.order(ByteOrder.LITTLE_ENDIAN)
 
             val stringIdsOff = buf.getInt(STRING_IDS_OFF_OFF)
@@ -98,7 +102,14 @@ internal object DexStripper {
 
             // Compact the class_data section: remove orphaned items, update pointers.
             if (orphanedClassDataOffsets.isNotEmpty()) {
-                compactClassData(buf, mapOff, classDefsOff, classDefsSize, indicesToRemove, orphanedClassDataOffsets)
+                compactClassData(
+                    buf,
+                    mapOff,
+                    classDefsOff,
+                    classDefsSize,
+                    indicesToRemove,
+                    orphanedClassDataOffsets
+                )
             }
 
             // Compact the class_defs array.
@@ -119,6 +130,13 @@ internal object DexStripper {
             mappedBuf.force()
 
             return indicesToRemove.size
+        }
+        finally {
+            if (EnvironmentUtils.isWindowsEnvironment) {
+                mappedBuf?.let { DexUtils.unsafeUnmap(it) }
+            }
+
+            raf.close()
         }
     }
 

--- a/src/main/kotlin/app/morphe/patcher/dex/DexUtils.kt
+++ b/src/main/kotlin/app/morphe/patcher/dex/DexUtils.kt
@@ -1,0 +1,17 @@
+package app.morphe.patcher.dex
+
+import sun.misc.Unsafe
+import java.nio.MappedByteBuffer
+
+object DexUtils {
+    fun unsafeUnmap(buffer: MappedByteBuffer) {
+        try {
+            val unsafeField = Unsafe::class.java.getDeclaredField("theUnsafe")
+            unsafeField.isAccessible = true
+            val unsafe = unsafeField.get(null) as Unsafe
+            unsafe.invokeCleaner(buffer)
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+}

--- a/src/main/kotlin/app/morphe/patcher/dex/MemoryBackedDexFile.kt
+++ b/src/main/kotlin/app/morphe/patcher/dex/MemoryBackedDexFile.kt
@@ -1,0 +1,19 @@
+package app.morphe.patcher.dex
+
+import app.morphe.patcher.environment.EnvironmentUtils
+import com.android.tools.smali.dexlib2.dexbacked.DexBackedDexFile
+import java.io.Closeable
+import java.nio.MappedByteBuffer
+import java.nio.channels.FileChannel
+
+internal class MemoryBackedDexFile(private val channel: FileChannel, private val buf: MappedByteBuffer)
+    : DexBackedDexFile(null, buf), Closeable {
+
+    constructor(channel: FileChannel) : this(channel,
+        channel.map(FileChannel.MapMode.READ_WRITE, 0, channel.size()))
+
+    override fun close() {
+        if (EnvironmentUtils.isWindowsEnvironment) DexUtils.unsafeUnmap(buf)
+        channel.close()
+    }
+}

--- a/src/main/kotlin/app/morphe/patcher/dex/MultidexReadResult.kt
+++ b/src/main/kotlin/app/morphe/patcher/dex/MultidexReadResult.kt
@@ -1,0 +1,48 @@
+package app.morphe.patcher.dex
+
+import app.morphe.patcher.environment.EnvironmentUtils
+import com.android.tools.smali.dexlib2.Opcodes
+import com.android.tools.smali.dexlib2.iface.ClassDef
+import com.android.tools.smali.dexlib2.iface.DexFile
+import java.io.Closeable
+import java.io.File
+import java.io.RandomAccessFile
+import java.nio.channels.FileChannel
+
+/**
+ * The result of reading a multidex file, containing both the merged [DexFile] view
+ * and the names of each individual DEX entry within the container.
+ *
+ * @param extractedDexFiles The names of each original DEX entry (e.g., "classes.dex", "classes2.dex")
+ */
+internal class MultidexReadResult(
+    val extractedDexFiles: List<File>
+) : Closeable {
+    val memoryMappedDexFiles = extractedDexFiles.map { file ->
+        MemoryBackedDexFile(RandomAccessFile(file, "rw").channel)
+    }
+
+    val dexFile = object : DexFile {
+        private val _opcodes: Opcodes by lazy {
+            memoryMappedDexFiles.maxByOrNull { it.opcodes.api }!!.opcodes
+        }
+        override fun getOpcodes(): Opcodes { return _opcodes }
+
+        override fun getClasses(): Set<ClassDef> {
+            return memoryMappedDexFiles.flatMap { it.classes }.toSet()
+        }
+    }
+
+    private val entryNames = extractedDexFiles.map { file -> file.name }
+    // Track which class descriptors belong to which DEX entry.
+    val classDescriptorsByEntry = entryNames.zip(memoryMappedDexFiles).associate { (name, dex) ->
+        name to dex.classes.let { classes ->
+            classes.mapTo(HashSet(2 * classes.size)) { it.type }
+        }
+    }
+
+    override fun close() {
+        if (EnvironmentUtils.isWindowsEnvironment)
+            memoryMappedDexFiles.forEach { it.close() }
+    }
+}

--- a/src/main/kotlin/app/morphe/patcher/environment/EnvironmentUtils.kt
+++ b/src/main/kotlin/app/morphe/patcher/environment/EnvironmentUtils.kt
@@ -11,4 +11,9 @@ object EnvironmentUtils {
      * True if the environment is Android.
      */
     val isAndroidEnvironment = System.getProperty("java.runtime.name") == "Android Runtime"
+
+    /**
+     * True if the environment is Windows.
+     */
+    val isWindowsEnvironment = System.getProperty("os.name").startsWith("Windows")
 }

--- a/src/main/kotlin/app/morphe/patcher/patch/BytecodePatchContext.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/BytecodePatchContext.kt
@@ -16,6 +16,7 @@ import app.morphe.patcher.StringComparisonType
 import app.morphe.patcher.dex.BytecodeMode
 import app.morphe.patcher.dex.DexReadWrite
 import app.morphe.patcher.dex.DexStripper
+import app.morphe.patcher.dex.MultidexReadResult
 import app.morphe.patcher.util.ClassMerger.merge
 import app.morphe.patcher.util.MethodNavigator
 import app.morphe.patcher.util.PatchClasses
@@ -71,20 +72,22 @@ class BytecodePatchContext internal constructor(private val config: PatcherConfi
     private val dexOutputDir = config.patchedFiles.resolve("dex")
     private val dexWorkingDir = config.patchedFiles.resolve("originalDex")
 
+    private lateinit var multidexReadResult: MultidexReadResult
+
     internal fun decodeDexFiles() {
         // Extract original DEX files from the APK to disk for later in-place editing.
         dexOutputDir.apply { deleteRecursively(); mkdirs() }
         dexWorkingDir.apply { deleteRecursively(); mkdirs()}
 
-        val readResult = DexReadWrite.readMultidexFileFromZip(config.apkFile, dexWorkingDir)
-        opcodes = readResult.dexFile.opcodes
-        originalClassDescriptors = readResult.dexFile.classes.let { classes ->
+        multidexReadResult = DexReadWrite.readMultidexFileFromZip(config.apkFile, dexWorkingDir)
+        opcodes = multidexReadResult.dexFile.opcodes
+        originalClassDescriptors = multidexReadResult.dexFile.classes.let { classes ->
             classes.mapTo(HashSet(2 * classes.size)) { it.type }
         }
-        classDescriptorsByEntry = readResult.classDescriptorsByEntry
-        patchClasses = PatchClasses(readResult.dexFile.classes)
+        classDescriptorsByEntry = multidexReadResult.classDescriptorsByEntry
+        patchClasses = PatchClasses(multidexReadResult.dexFile.classes)
 
-        originalDexFiles = readResult.extractedDexFiles
+        originalDexFiles = multidexReadResult.extractedDexFiles
     }
 
     /**
@@ -445,5 +448,6 @@ class BytecodePatchContext internal constructor(private val config: PatcherConfi
 
     override fun close() {
         patchClasses.close()
+        multidexReadResult.close()
     }
 }

--- a/src/main/kotlin/app/morphe/patcher/patch/Patch.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/Patch.kt
@@ -766,11 +766,12 @@ sealed class PatchLoader(
             patchesFiles,
             { patchBundle ->
                 val tempDir = Files.createTempDirectory("morphe-extracted-patches").toFile()
-                DexReadWrite.readMultidexFileFromZip(patchBundle, tempDir)
-                    .dexFile.classes
+                DexReadWrite.readMultidexFileFromZip(patchBundle, tempDir).use {
+                    it.dexFile.classes
                     .map { classDef ->
                         classDef.type.substring(1, classDef.length - 1)
                     }
+                }
             },
             DexClassLoader(
                 patchesFiles.joinToString(File.pathSeparator) { it.absolutePath },


### PR DESCRIPTION
I haven't really tested this yet. Just wanted to make sure that the approach/assumptions were correct first.