### PR TITLE
feat: Expose APK signing certificates to patches

### DIFF
--- a/api/morphe-patcher.api
+++ b/api/morphe-patcher.api
@@ -278,6 +278,7 @@ public final class app/morphe/patcher/OpcodesFilter$Companion {
 
 public final class app/morphe/patcher/PackageMetadata {
 	public final fun getPackageName ()Ljava/lang/String;
+	public final fun getSigningCertificates ()Ljava/util/Map;
 	public final fun getVersionCode ()Ljava/lang/String;
 	public final fun getVersionName ()Ljava/lang/String;
 }
@@ -346,6 +347,24 @@ public final class app/morphe/patcher/apk/ApkMerger {
 	public synthetic fun <init> (Lapp/morphe/patcher/logging/Logger;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun merge (Ljava/io/File;Ljava/io/File;ZLjava/lang/String;ZLjava/lang/Boolean;Z)V
 	public static synthetic fun merge$default (Lapp/morphe/patcher/apk/ApkMerger;Ljava/io/File;Ljava/io/File;ZLjava/lang/String;ZLjava/lang/Boolean;ZILjava/lang/Object;)V
+}
+
+public final class app/morphe/patcher/apk/ApkSignatureScheme {
+	public static final field Companion Lapp/morphe/patcher/apk/ApkSignatureScheme$Companion;
+	public fun <init> (I)V
+	public final fun component1 ()I
+	public final fun copy (I)Lapp/morphe/patcher/apk/ApkSignatureScheme;
+	public static synthetic fun copy$default (Lapp/morphe/patcher/apk/ApkSignatureScheme;IILjava/lang/Object;)Lapp/morphe/patcher/apk/ApkSignatureScheme;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/morphe/patcher/apk/ApkSignatureScheme$Companion {
+	public final fun getV2 ()Lapp/morphe/patcher/apk/ApkSignatureScheme;
+	public final fun getV3 ()Lapp/morphe/patcher/apk/ApkSignatureScheme;
+	public final fun getV31 ()Lapp/morphe/patcher/apk/ApkSignatureScheme;
 }
 
 public final class app/morphe/patcher/apk/ApkSigner {
@@ -955,54 +974,6 @@ public final class app/morphe/patcher/resource/XmlPullParserUtilsKt {
 	public static final fun parseXml (Ljava/io/File;Lkotlin/jvm/functions/Function1;)V
 	public static final fun skipTag (Lorg/xmlpull/v1/XmlPullParser;)V
 	public static final fun writeXml (Ljava/io/File;Lkotlin/jvm/functions/Function1;)V
-}
-
-public final class app/morphe/patcher/resource/coder/ArsclibResourceCoder : app/morphe/patcher/resource/coder/ResourceCoder {
-	public fun <init> (Ljava/io/File;Ljava/io/File;Ljava/util/Set;)V
-	public synthetic fun <init> (Ljava/io/File;Ljava/io/File;Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun addFile (Ljava/lang/String;Ljava/io/File;Ljava/lang/String;)Ljava/io/File;
-	public fun close ()V
-	public fun decodeRaw ()Lapp/morphe/patcher/PackageMetadata;
-	public fun decodeResources ()Lapp/morphe/patcher/PackageMetadata;
-	public fun deleteFile (Ljava/lang/String;Ljava/lang/String;)V
-	public fun encodeResources (Ljava/io/File;)Ljava/io/File;
-	public fun getDeletedFiles (Lapp/morphe/patcher/resource/ResourceMode;)Ljava/util/Set;
-	public fun getFile (Ljava/lang/String;Ljava/lang/String;Z)Ljava/io/File;
-	public fun getOtherResourceFiles (Ljava/io/File;Lapp/morphe/patcher/resource/ResourceMode;)Ljava/io/File;
-	public fun getPackageMetadata ()Lapp/morphe/patcher/PackageMetadata;
-	public fun getUncompressedFiles (Lapp/morphe/patcher/resource/ResourceMode;)Ljava/util/Set;
-}
-
-public final class app/morphe/patcher/resource/coder/ArsclibResourceCoder$PackageInfo {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)V
-	public final fun getFrameworkVersion ()I
-	public final fun getPackageName ()Ljava/lang/String;
-	public final fun getVersionCode ()Ljava/lang/String;
-	public final fun getVersionName ()Ljava/lang/String;
-}
-
-public abstract interface class app/morphe/patcher/resource/coder/ResourceCoder : java/io/Closeable {
-	public abstract fun addFile (Ljava/lang/String;Ljava/io/File;Ljava/lang/String;)Ljava/io/File;
-	public static synthetic fun addFile$default (Lapp/morphe/patcher/resource/coder/ResourceCoder;Ljava/lang/String;Ljava/io/File;Ljava/lang/String;ILjava/lang/Object;)Ljava/io/File;
-	public fun close ()V
-	public abstract fun decodeRaw ()Lapp/morphe/patcher/PackageMetadata;
-	public abstract fun decodeResources ()Lapp/morphe/patcher/PackageMetadata;
-	public abstract fun deleteFile (Ljava/lang/String;Ljava/lang/String;)V
-	public static synthetic fun deleteFile$default (Lapp/morphe/patcher/resource/coder/ResourceCoder;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
-	public abstract fun encodeResources (Ljava/io/File;)Ljava/io/File;
-	public abstract fun getDeletedFiles (Lapp/morphe/patcher/resource/ResourceMode;)Ljava/util/Set;
-	public abstract fun getFile (Ljava/lang/String;Ljava/lang/String;Z)Ljava/io/File;
-	public static synthetic fun getFile$default (Lapp/morphe/patcher/resource/coder/ResourceCoder;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Ljava/io/File;
-	public abstract fun getOtherResourceFiles (Ljava/io/File;Lapp/morphe/patcher/resource/ResourceMode;)Ljava/io/File;
-	public abstract fun getPackageMetadata ()Lapp/morphe/patcher/PackageMetadata;
-	public abstract fun getUncompressedFiles (Lapp/morphe/patcher/resource/ResourceMode;)Ljava/util/Set;
-}
-
-public final class app/morphe/patcher/resource/coder/ResourceCoder$DefaultImpls {
-	public static synthetic fun addFile$default (Lapp/morphe/patcher/resource/coder/ResourceCoder;Ljava/lang/String;Ljava/io/File;Ljava/lang/String;ILjava/lang/Object;)Ljava/io/File;
-	public static fun close (Lapp/morphe/patcher/resource/coder/ResourceCoder;)V
-	public static synthetic fun deleteFile$default (Lapp/morphe/patcher/resource/coder/ResourceCoder;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
-	public static synthetic fun getFile$default (Lapp/morphe/patcher/resource/coder/ResourceCoder;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Ljava/io/File;
 }
 
 public final class app/morphe/patcher/util/Document : java/io/Closeable, org/w3c/dom/Document {

--- a/src/main/kotlin/app/morphe/patcher/PackageMetadata.kt
+++ b/src/main/kotlin/app/morphe/patcher/PackageMetadata.kt
@@ -8,15 +8,49 @@
 
 package app.morphe.patcher
 
+import app.morphe.patcher.apk.ApkSignatureScheme
+import com.reandroid.archive.block.ApkSignatureBlock
+import java.security.cert.X509Certificate
+
 /**
  * Metadata about a package.
  *
  * @param packageName The name of the package.
  * @param versionCode The version code of the package.
  * @param versionName The version name of the package.
+ * @param signatureBlock The APK signature block of the package, or `null` if the package is unsigned.
  */
 class PackageMetadata internal constructor(
     val packageName: String,
     val versionName: String,
     val versionCode: String,
-)
+    private val signatureBlock: ApkSignatureBlock?
+) {
+    /**
+     * Get the signing certificates of the package, grouped by the [ApkSignatureScheme] they belong to.
+     *
+     * A single APK signing block can hold multiple signature schemes (for example,
+     * [ApkSignatureScheme.V2] and [ApkSignatureScheme.V3]), in which case the same signer
+     * certificate is usually present under each scheme that was used to sign the package.
+     *
+     * Only certificates that can be parsed are included. Schemes that do not carry any parseable
+     * certificate, such as padding, source stamp, or unrecognized blocks, map to an empty list.
+     * If the package is unsigned, an empty map is returned.
+     *
+     * @return A map of each [ApkSignatureScheme] present in the signing block to its [X509Certificate]s.
+     */
+    val signingCertificates: Map<ApkSignatureScheme, List<X509Certificate>> by lazy {
+        buildMap {
+            signatureBlock?.forEach { signatureInfo ->
+                put(
+                    ApkSignatureScheme.fromSignatureId(signatureInfo.id),
+                    buildList {
+                        signatureInfo.certificates.forEach { certificateBlock ->
+                            certificateBlock.certificate?.also{ add(it) }
+                        }
+                    }
+                )
+            }
+        }
+    }
+}

--- a/src/main/kotlin/app/morphe/patcher/apk/ApkMerger.kt
+++ b/src/main/kotlin/app/morphe/patcher/apk/ApkMerger.kt
@@ -48,7 +48,7 @@ class ApkMerger(
         resDirName: String? = null,
         validateResDir: Boolean = true,
         extractNativeLibs: Boolean? = null,
-        cleanMetaInf: Boolean = true
+        cleanMetaInf: Boolean = false
     ) {
         outputFile.safelyDelete()
         var dir: File = inputFile
@@ -71,10 +71,13 @@ class ApkMerger(
             logger.info("Validating resources dir ...")
             mergedModule.validateResourcesDir()
         }
+        /*
+        // Ignore cleanMetaInf so that we always retain the signature block (this is leftover code from APKEditor).
         if (cleanMetaInf) {
             logger.info("Clearing META-INF ...")
             clearMeta(mergedModule)
         }
+        */
         sanitizeManifest(mergedModule)
         mergedModule.refreshTable()
         mergedModule.refreshManifest()
@@ -225,11 +228,5 @@ class ApkMerger(
             specTypePair.removeNullEntries(entry.getId())
         }
         return true
-    }
-    private fun clearMeta(module: ApkModule) {
-        val archive = module.zipEntryMap
-        archive.removeIf(Pattern.compile("^META-INF/.+\\.(([MS]F)|(RSA))"))
-        archive.remove("stamp-cert-sha256")
-        module.apkSignatureBlock = null
     }
 }

--- a/src/main/kotlin/app/morphe/patcher/apk/ApkSignatureScheme.kt
+++ b/src/main/kotlin/app/morphe/patcher/apk/ApkSignatureScheme.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patcher
+ */
+
+package app.morphe.patcher.apk
+
+import com.reandroid.archive.block.SignatureId
+
+/**
+ * An APK signature scheme, identified by the ID of its block within the APK Signing Block.
+ *
+ * Well-known schemes are provided as constants ([V2], [V3], [V31]). Any other scheme, including
+ * ones not recognized by this class (such as source stamps, padding, or future schemes), is
+ * represented by an instance carrying that raw [id], so arbitrary schemes can still be
+ * distinguished and compared.
+ *
+ * @property id The ID of the signature scheme's block within the APK Signing Block.
+ */
+data class ApkSignatureScheme(val id: Int) {
+    companion object {
+        /** APK Signature Scheme v2. */
+        val V2 = ApkSignatureScheme(SignatureId.V2.id)
+
+        /** APK Signature Scheme v3. */
+        val V3 = ApkSignatureScheme(SignatureId.V3.id)
+
+        /** APK Signature Scheme v3.1. */
+        val V31 = ApkSignatureScheme(SignatureId.V31.id)
+
+        /**
+         * Create an [ApkSignatureScheme] from an ARSCLib [SignatureId].
+         *
+         * @param signatureId The signature ID whose block ID is used.
+         * @return An [ApkSignatureScheme] whose [id] is the block ID of [signatureId].
+         */
+        internal fun fromSignatureId(signatureId: SignatureId): ApkSignatureScheme = ApkSignatureScheme(signatureId.id)
+    }
+}

--- a/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
@@ -28,6 +28,7 @@ import com.reandroid.apk.ApkModule
 import com.reandroid.apk.ApkModuleRawDecoder
 import com.reandroid.apk.ApkModuleXmlDecoder
 import com.reandroid.apk.ApkModuleXmlEncoder
+import com.reandroid.archive.block.ApkSignatureBlock
 import com.reandroid.arsc.coder.CoderSetting
 import com.reandroid.arsc.coder.xml.AaptXmlStringDecoder
 import com.reandroid.arsc.coder.xml.XmlCoder
@@ -38,7 +39,7 @@ import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 import java.util.logging.Logger
 
-class ArsclibResourceCoder(
+internal class ArsclibResourceCoder(
     internal val workingDir: File,
     internal val apkFile: File,
     private val keepArchitectures: Set<CpuArchitecture> = emptySet()
@@ -133,6 +134,7 @@ class ArsclibResourceCoder(
         val versionName: String,
         val versionCode: String,
         val frameworkVersion: Int,
+        val signatureBlock: ApkSignatureBlock?
     )
 
     private val lazyPackageInfo = lazy {
@@ -143,6 +145,7 @@ class ArsclibResourceCoder(
                 manifest.versionName,
                 manifest.versionCode.toString(),
                 module.androidFrameworkVersion,
+                module.apkSignatureBlock
             )
         }
     }
@@ -160,7 +163,8 @@ class ArsclibResourceCoder(
         return PackageMetadata(
             lazyPackageInfo.value.packageName,
             lazyPackageInfo.value.versionName,
-            lazyPackageInfo.value.versionCode
+            lazyPackageInfo.value.versionCode,
+            lazyPackageInfo.value.signatureBlock
         )
     }
 

--- a/src/main/kotlin/app/morphe/patcher/resource/coder/ResourceCoder.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/coder/ResourceCoder.kt
@@ -10,7 +10,7 @@ import app.morphe.patcher.resource.ResourceMode
 import java.io.Closeable
 import java.io.File
 
-interface ResourceCoder : Closeable {
+internal interface ResourceCoder : Closeable {
     /**
      * No-op default implementation. Override to release resources held by the coder.
      */

--- a/src/test/kotlin/app/morphe/patcher/PackageMetadataTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/PackageMetadataTest.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patcher
+ */
+
+package app.morphe.patcher
+
+import app.morphe.patcher.apk.ApkSignatureScheme
+import com.reandroid.archive.block.ApkSignatureBlock
+import com.reandroid.archive.block.CertificateBlock
+import com.reandroid.archive.block.SignatureId
+import com.reandroid.archive.block.SignatureInfo
+import io.mockk.every
+import io.mockk.mockk
+import java.security.cert.X509Certificate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+internal class PackageMetadataTest {
+
+    @Test
+    fun `signingCertificates returns an empty map when the package is unsigned`() {
+        val metadata = packageMetadata(signatureBlock = null)
+
+        assertTrue(metadata.signingCertificates.isEmpty())
+    }
+
+    @Test
+    fun `signingCertificates groups certificates by signature scheme`() {
+        val certificate = mockk<X509Certificate>()
+        val metadata = packageMetadata(
+            signatureBlock(
+                signatureInfo(SignatureId.V2, certBlock(certificate)),
+                signatureInfo(SignatureId.V3, certBlock(certificate)),
+            ),
+        )
+
+        assertEquals(
+            mapOf(
+                ApkSignatureScheme.V2 to listOf(certificate),
+                ApkSignatureScheme.V3 to listOf(certificate),
+            ),
+            metadata.signingCertificates,
+        )
+    }
+
+    @Test
+    fun `signingCertificates keeps every certificate of a scheme in order`() {
+        val first = mockk<X509Certificate>()
+        val second = mockk<X509Certificate>()
+        val metadata = packageMetadata(
+            signatureBlock(
+                signatureInfo(SignatureId.V3, certBlock(first), certBlock(second)),
+            ),
+        )
+
+        assertEquals(listOf(first, second), metadata.signingCertificates[ApkSignatureScheme.V3])
+    }
+
+    @Test
+    fun `signingCertificates skips certificates that fail to parse`() {
+        val certificate = mockk<X509Certificate>()
+        val metadata = packageMetadata(
+            signatureBlock(
+                signatureInfo(SignatureId.V2, certBlock(null), certBlock(certificate), certBlock(null)),
+            ),
+        )
+
+        assertEquals(listOf(certificate), metadata.signingCertificates[ApkSignatureScheme.V2])
+    }
+
+    @Test
+    fun `signingCertificates maps a scheme without parseable certificates to an empty list`() {
+        val metadata = packageMetadata(
+            signatureBlock(
+                signatureInfo(SignatureId.V2, certBlock(null)),
+            ),
+        )
+
+        assertEquals(
+            mapOf(ApkSignatureScheme.V2 to emptyList<X509Certificate>()),
+            metadata.signingCertificates,
+        )
+    }
+
+    @Test
+    fun `signingCertificates maps a non-certificate scheme to an empty list`() {
+        val metadata = packageMetadata(
+            signatureBlock(
+                signatureInfo(SignatureId.PADDING),
+            ),
+        )
+
+        assertEquals(
+            mapOf(ApkSignatureScheme(SignatureId.PADDING.id) to emptyList<X509Certificate>()),
+            metadata.signingCertificates,
+        )
+    }
+
+    @Test
+    fun `signingCertificates preserves an unrecognized signature scheme id`() {
+        val unknownId = 0x12345678
+        val certificate = mockk<X509Certificate>()
+        val metadata = packageMetadata(
+            signatureBlock(
+                signatureInfo(SignatureId.valueOf(unknownId), certBlock(certificate)),
+            ),
+        )
+
+        assertEquals(
+            mapOf(ApkSignatureScheme(unknownId) to listOf(certificate)),
+            metadata.signingCertificates,
+        )
+    }
+
+    private fun packageMetadata(signatureBlock: ApkSignatureBlock?) =
+        PackageMetadata("com.test.app", "1.0.0", "1", signatureBlock)
+
+    private fun certBlock(certificate: X509Certificate?): CertificateBlock {
+        val block = mockk<CertificateBlock>()
+        every { block.certificate } returns certificate
+        return block
+    }
+
+    private fun signatureInfo(signatureId: SignatureId, vararg certificates: CertificateBlock): SignatureInfo {
+        val info = mockk<SignatureInfo>()
+        every { info.id } returns signatureId
+        every { info.certificates } answers { certificates.toMutableList().iterator() }
+        return info
+    }
+
+    private fun signatureBlock(vararg signatures: SignatureInfo): ApkSignatureBlock {
+        val block = mockk<ApkSignatureBlock>()
+        every { block.iterator() } answers { signatures.toMutableList().iterator() }
+        return block
+    }
+}

--- a/src/test/kotlin/app/morphe/patcher/apk/ApkSignatureSchemeTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/apk/ApkSignatureSchemeTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patcher
+ */
+
+package app.morphe.patcher.apk
+
+import com.reandroid.archive.block.SignatureId
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+internal class ApkSignatureSchemeTest {
+
+    @Test
+    fun `well-known schemes expose the expected APK Signing Block ids`() {
+        assertEquals(0x7109871A, ApkSignatureScheme.V2.id)
+        assertEquals(0xF05368C0.toInt(), ApkSignatureScheme.V3.id)
+        assertEquals(0x1B93AD61, ApkSignatureScheme.V31.id)
+    }
+
+    @Test
+    fun `well-known schemes match their SignatureId`() {
+        assertEquals(SignatureId.V2.id, ApkSignatureScheme.V2.id)
+        assertEquals(SignatureId.V3.id, ApkSignatureScheme.V3.id)
+        assertEquals(SignatureId.V31.id, ApkSignatureScheme.V31.id)
+    }
+
+    @Test
+    fun `well-known schemes are distinct from one another`() {
+        assertNotEquals(ApkSignatureScheme.V2, ApkSignatureScheme.V3)
+        assertNotEquals(ApkSignatureScheme.V3, ApkSignatureScheme.V31)
+        assertNotEquals(ApkSignatureScheme.V2, ApkSignatureScheme.V31)
+    }
+
+    @Test
+    fun `fromSignatureId maps known ids to their constants`() {
+        assertEquals(ApkSignatureScheme.V2, ApkSignatureScheme.fromSignatureId(SignatureId.V2))
+        assertEquals(ApkSignatureScheme.V3, ApkSignatureScheme.fromSignatureId(SignatureId.V3))
+        assertEquals(ApkSignatureScheme.V31, ApkSignatureScheme.fromSignatureId(SignatureId.V31))
+    }
+
+    @Test
+    fun `fromSignatureId preserves arbitrary ids`() {
+        val unknownId = 0x12345678
+        val scheme = ApkSignatureScheme.fromSignatureId(SignatureId.valueOf(unknownId))
+
+        assertEquals(ApkSignatureScheme(unknownId), scheme)
+        assertEquals(unknownId, scheme.id)
+    }
+
+    @Test
+    fun `an arbitrary scheme does not equal a well-known scheme`() {
+        assertNotEquals(ApkSignatureScheme.V2, ApkSignatureScheme(0x12345678))
+    }
+
+    @Test
+    fun `schemes with the same id are equal`() {
+        assertEquals(ApkSignatureScheme.V2, ApkSignatureScheme(SignatureId.V2.id))
+    }
+}


### PR DESCRIPTION
Closes #144.

Also changes ArsclibResourceCoder and ResourceCoder to be internal, since they are not meant to be used by patches.