### PR TITLE
feat: Add typed patch options

### DIFF
--- a/api/morphe-patcher.api
+++ b/api/morphe-patcher.api
@@ -619,6 +619,12 @@ public final class app/morphe/patcher/patch/BytecodePatchContext : app/morphe/pa
 	public final fun navigate (Lcom/android/tools/smali/dexlib2/iface/reference/MethodReference;)Lapp/morphe/patcher/util/MethodNavigator;
 }
 
+public final class app/morphe/patcher/patch/ColorOption : app/morphe/patcher/patch/StringOption {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getColorInt ()Ljava/lang/Integer;
+}
+
 public final class app/morphe/patcher/patch/Compatibility {
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lapp/morphe/patcher/patch/ApkFileType;Ljava/lang/Integer;Ljava/util/Set;Ljava/util/List;)V
@@ -648,7 +654,46 @@ public final class app/morphe/patcher/patch/Compatibility {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class app/morphe/patcher/patch/Option {
+public final class app/morphe/patcher/patch/FilePathOption : app/morphe/patcher/patch/StringOption {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Lkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAllowedExtensions ()Ljava/util/List;
+}
+
+public final class app/morphe/patcher/patch/FilesOption : app/morphe/patcher/patch/Option {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Lkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAllowedExtensions ()Ljava/util/List;
+	public final fun getFiles ()Ljava/util/List;
+}
+
+public final class app/morphe/patcher/patch/FolderOption : app/morphe/patcher/patch/StringOption {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getDirectory ()Ljava/io/File;
+}
+
+public final class app/morphe/patcher/patch/ImageOption : app/morphe/patcher/patch/StringOption {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Lapp/morphe/patcher/patch/ImageSize;Lkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Lapp/morphe/patcher/patch/ImageSize;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAllowedExtensions ()Ljava/util/List;
+	public final fun getRecommendedSize ()Lapp/morphe/patcher/patch/ImageSize;
+}
+
+public final class app/morphe/patcher/patch/ImageSize {
+	public fun <init> (II)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun copy (II)Lapp/morphe/patcher/patch/ImageSize;
+	public static synthetic fun copy$default (Lapp/morphe/patcher/patch/ImageSize;IIILjava/lang/Object;)Lapp/morphe/patcher/patch/ImageSize;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHeight ()I
+	public final fun getWidth ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public class app/morphe/patcher/patch/Option {
 	public fun <init> (Ljava/lang/String;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;ZLkotlin/reflect/KType;Lkotlin/jvm/functions/Function2;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;ZLkotlin/reflect/KType;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/String;ZLkotlin/reflect/KType;Lkotlin/jvm/functions/Function2;)V
@@ -881,6 +926,29 @@ public final class app/morphe/patcher/patch/PatchUtilsKt {
 	public static final fun setOptions (Ljava/util/Set;Ljava/util/Map;)V
 }
 
+public final class app/morphe/patcher/patch/PathOptionsKt {
+	public static final fun colorOption (Lapp/morphe/patcher/patch/PatchBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;)Lapp/morphe/patcher/patch/ColorOption;
+	public static final fun colorOption (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;)Lapp/morphe/patcher/patch/ColorOption;
+	public static synthetic fun colorOption$default (Lapp/morphe/patcher/patch/PatchBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lapp/morphe/patcher/patch/ColorOption;
+	public static synthetic fun colorOption$default (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lapp/morphe/patcher/patch/ColorOption;
+	public static final fun filePathOption (Lapp/morphe/patcher/patch/PatchBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Lkotlin/jvm/functions/Function2;)Lapp/morphe/patcher/patch/FilePathOption;
+	public static final fun filePathOption (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Lkotlin/jvm/functions/Function2;)Lapp/morphe/patcher/patch/FilePathOption;
+	public static synthetic fun filePathOption$default (Lapp/morphe/patcher/patch/PatchBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lapp/morphe/patcher/patch/FilePathOption;
+	public static synthetic fun filePathOption$default (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lapp/morphe/patcher/patch/FilePathOption;
+	public static final fun filesOption (Lapp/morphe/patcher/patch/PatchBuilder;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Lkotlin/jvm/functions/Function2;)Lapp/morphe/patcher/patch/FilesOption;
+	public static final fun filesOption (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Lkotlin/jvm/functions/Function2;)Lapp/morphe/patcher/patch/FilesOption;
+	public static synthetic fun filesOption$default (Lapp/morphe/patcher/patch/PatchBuilder;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lapp/morphe/patcher/patch/FilesOption;
+	public static synthetic fun filesOption$default (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lapp/morphe/patcher/patch/FilesOption;
+	public static final fun folderOption (Lapp/morphe/patcher/patch/PatchBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;)Lapp/morphe/patcher/patch/FolderOption;
+	public static final fun folderOption (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;)Lapp/morphe/patcher/patch/FolderOption;
+	public static synthetic fun folderOption$default (Lapp/morphe/patcher/patch/PatchBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lapp/morphe/patcher/patch/FolderOption;
+	public static synthetic fun folderOption$default (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lapp/morphe/patcher/patch/FolderOption;
+	public static final fun imageOption (Lapp/morphe/patcher/patch/PatchBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Lapp/morphe/patcher/patch/ImageSize;Lkotlin/jvm/functions/Function2;)Lapp/morphe/patcher/patch/ImageOption;
+	public static final fun imageOption (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Lapp/morphe/patcher/patch/ImageSize;Lkotlin/jvm/functions/Function2;)Lapp/morphe/patcher/patch/ImageOption;
+	public static synthetic fun imageOption$default (Lapp/morphe/patcher/patch/PatchBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Lapp/morphe/patcher/patch/ImageSize;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lapp/morphe/patcher/patch/ImageOption;
+	public static synthetic fun imageOption$default (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Lapp/morphe/patcher/patch/ImageSize;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lapp/morphe/patcher/patch/ImageOption;
+}
+
 public final class app/morphe/patcher/patch/RawResourcePatch : app/morphe/patcher/patch/Patch {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/util/Set;Ljava/util/Set;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
 	public fun toString ()Ljava/lang/String;
@@ -911,6 +979,12 @@ public final class app/morphe/patcher/patch/ResourcePatchContext : app/morphe/pa
 	public final fun get (Ljava/lang/String;Z)Ljava/io/File;
 	public static synthetic fun get$default (Lapp/morphe/patcher/patch/ResourcePatchContext;Ljava/lang/String;ZILjava/lang/Object;)Ljava/io/File;
 	public final fun getPackageMetadata ()Lapp/morphe/patcher/PackageMetadata;
+}
+
+public class app/morphe/patcher/patch/StringOption : app/morphe/patcher/patch/Option {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getFile ()Ljava/io/File;
 }
 
 public final class app/morphe/patcher/patch/SupportedAbi : java/lang/Enum {

--- a/src/main/kotlin/app/morphe/patcher/patch/Option.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/Option.kt
@@ -20,7 +20,7 @@ import kotlin.reflect.typeOf
  * @constructor Create a new [Option].
  */
 @Suppress("MemberVisibilityCanBePrivate", "unused")
-class Option<T>
+open class Option<T>
 @PublishedApi
 @Deprecated("Use the constructor with the name instead of a key instead.")
 internal constructor(
@@ -202,15 +202,7 @@ fun stringOption(
     description: String? = null,
     required: Boolean = false,
     validator: Option<String>.(String?) -> Boolean = { true },
-) = option(
-    key,
-    default,
-    values,
-    title,
-    description,
-    required,
-    validator,
-)
+): Option<String> = StringOption(key, default, values, title, description, required, validator)
 
 /**
  * Create a new [Option] with a string value and add it to the current [PatchBuilder].
@@ -235,15 +227,9 @@ fun PatchBuilder<*>.stringOption(
     description: String? = null,
     required: Boolean = false,
     validator: Option<String>.(String?) -> Boolean = { true },
-) = option(
-    key,
-    default,
-    values,
-    title,
-    description,
-    required,
-    validator,
-)
+): Option<String> = app.morphe.patcher.patch.stringOption(
+    key, default, values, title, description, required, validator,
+).also { it() }
 
 /**
  * Create a new [Option] with an integer value.

--- a/src/main/kotlin/app/morphe/patcher/patch/PathOptions.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/PathOptions.kt
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patcher
+ */
+
+@file:Suppress("unused", "DEPRECATION")
+
+package app.morphe.patcher.patch
+
+import java.io.File
+import kotlin.reflect.typeOf
+
+/**
+ * Recommended pixel dimensions for an [ImageOption].
+ *
+ * @param width  Recommended width in pixels.
+ * @param height Recommended height in pixels.
+ */
+data class ImageSize(val width: Int, val height: Int)
+
+/**
+ * Base class for string-valued [Option]s. Subclasses ([FolderOption], [FilePathOption],
+ * [ImageOption], [ColorOption]) add semantic hints (picker kind, MIME filters,
+ * presets) and typed accessors while preserving [String] as the underlying value.
+ * Consumers that treat the option as `Option<String>` see and mutate the same
+ * plain string as with a raw [stringOption].
+ */
+open class StringOption @PublishedApi internal constructor(
+    key: String,
+    default: String? = null,
+    values: Map<String, String?>? = null,
+    title: String? = null,
+    description: String? = null,
+    required: Boolean = false,
+    validator: Option<String>.(String?) -> Boolean = { true },
+) : Option<String>(
+    key,
+    default,
+    values,
+    title,
+    description,
+    required,
+    typeOf<String>(),
+    validator,
+) {
+    /**
+     * The current [value] as a [File], or `null` when unset or blank.
+     * The path is not stat'ed. Callers should still check [File.exists] etc.
+     */
+    val file: File? get() = value?.takeIf { it.isNotBlank() }?.let(::File)
+}
+
+/**
+ * A folder-path option. Signals to editors that this option should be edited
+ * via a folder picker rather than a text field.
+ */
+class FolderOption @PublishedApi internal constructor(
+    key: String,
+    default: String? = null,
+    title: String? = null,
+    description: String? = null,
+    required: Boolean = false,
+    validator: Option<String>.(String?) -> Boolean = { true },
+) : StringOption(key, default, null, title, description, required, validator) {
+    /** Alias for [file]. */
+    val directory: File? get() = file
+}
+
+/**
+ * A single-file-path option. Signals to editors that this option should be
+ * edited via a file picker.
+ *
+ * @property allowedExtensions Optional file extensions the picker should filter by
+ *   (e.g. `listOf("apk", "zip")`). `null` means any file.
+ */
+class FilePathOption @PublishedApi internal constructor(
+    key: String,
+    default: String? = null,
+    title: String? = null,
+    description: String? = null,
+    required: Boolean = false,
+    val allowedExtensions: List<String>? = null,
+    validator: Option<String>.(String?) -> Boolean = { true },
+) : StringOption(key, default, null, title, description, required, validator)
+
+/**
+ * A multi-file-path option. Signals to editors that this option should be edited
+ * via a file picker that allows selecting multiple files.
+ *
+ * The stored value is a list of file paths.
+ *
+ * @property allowedExtensions Optional file extensions the picker should filter by.
+ */
+class FilesOption @PublishedApi internal constructor(
+    key: String,
+    default: List<String>? = null,
+    title: String? = null,
+    description: String? = null,
+    required: Boolean = false,
+    val allowedExtensions: List<String>? = null,
+    validator: Option<List<String>>.(List<String>?) -> Boolean = { true },
+) : Option<List<String>>(
+    key,
+    default,
+    null,
+    title,
+    description,
+    required,
+    typeOf<List<String>>(),
+    validator,
+) {
+    /** The current list of paths as [File] instances, or `null` when unset. */
+    val files: List<File>? get() = value?.map(::File)
+}
+
+/**
+ * An image-file option. Signals to editors that this option should be edited via
+ * a file picker restricted to image files. The stored value is a file path.
+ *
+ * @property allowedExtensions File extensions the picker should filter by. Defaults
+ *   to common image formats (`png`, `jpg`, `jpeg`, `webp`).
+ * @property recommendedSize Optional recommended pixel dimensions the editor may
+ *   show as a hint to the user.
+ */
+class ImageOption @PublishedApi internal constructor(
+    key: String,
+    default: String? = null,
+    title: String? = null,
+    description: String? = null,
+    required: Boolean = false,
+    val allowedExtensions: List<String>? = listOf("png", "jpg", "jpeg", "webp"),
+    val recommendedSize: ImageSize? = null,
+    validator: Option<String>.(String?) -> Boolean = { true },
+) : StringOption(key, default, null, title, description, required, validator)
+
+/**
+ * A color option. Signals to editors that this option should be edited via a
+ * color picker. The stored value is a hex color string, e.g. `"#FF00AA"`.
+ *
+ * Presets may be provided via [values] mapping human-readable names to hex strings.
+ */
+class ColorOption @PublishedApi internal constructor(
+    key: String,
+    default: String? = null,
+    values: Map<String, String?>? = null,
+    title: String? = null,
+    description: String? = null,
+    required: Boolean = false,
+    validator: Option<String>.(String?) -> Boolean = { true },
+) : StringOption(key, default, values, title, description, required, validator) {
+    /**
+     * The current hex color parsed to an ARGB int, or `null` when unset, blank,
+     * malformed, or an Android resource reference (e.g. "@android:color/black")
+     * that requires a resource context to resolve.
+     *
+     * Accepts `#RRGGBB` (alpha assumed opaque) and `#AARRGGBB`.
+     */
+    val colorInt: Int? get() {
+        val hex = value?.trim()?.removePrefix("#") ?: return null
+        return when (hex.length) {
+            6 -> "FF$hex".toLongOrNull(16)?.toInt()
+            8 -> hex.toLongOrNull(16)?.toInt()
+            else -> null
+        }
+    }
+}
+
+// region Builders
+
+/**
+ * Create a new [FolderOption].
+ */
+fun folderOption(
+    key: String,
+    default: String? = null,
+    title: String? = null,
+    description: String? = null,
+    required: Boolean = false,
+    validator: Option<String>.(String?) -> Boolean = { true },
+) = FolderOption(key, default, title, description, required, validator)
+
+/**
+ * Create a new [FolderOption] and add it to the current [PatchBuilder].
+ */
+fun PatchBuilder<*>.folderOption(
+    key: String,
+    default: String? = null,
+    title: String? = null,
+    description: String? = null,
+    required: Boolean = false,
+    validator: Option<String>.(String?) -> Boolean = { true },
+): FolderOption = app.morphe.patcher.patch.folderOption(
+    key, default, title, description, required, validator,
+).also { it() }
+
+/**
+ * Create a new [FilePathOption].
+ */
+fun filePathOption(
+    key: String,
+    default: String? = null,
+    title: String? = null,
+    description: String? = null,
+    required: Boolean = false,
+    allowedExtensions: List<String>? = null,
+    validator: Option<String>.(String?) -> Boolean = { true },
+) = FilePathOption(key, default, title, description, required, allowedExtensions, validator)
+
+/**
+ * Create a new [FilePathOption] and add it to the current [PatchBuilder].
+ */
+fun PatchBuilder<*>.filePathOption(
+    key: String,
+    default: String? = null,
+    title: String? = null,
+    description: String? = null,
+    required: Boolean = false,
+    allowedExtensions: List<String>? = null,
+    validator: Option<String>.(String?) -> Boolean = { true },
+): FilePathOption = app.morphe.patcher.patch.filePathOption(
+    key, default, title, description, required, allowedExtensions, validator,
+).also { it() }
+
+/**
+ * Create a new [FilesOption].
+ */
+fun filesOption(
+    key: String,
+    default: List<String>? = null,
+    title: String? = null,
+    description: String? = null,
+    required: Boolean = false,
+    allowedExtensions: List<String>? = null,
+    validator: Option<List<String>>.(List<String>?) -> Boolean = { true },
+) = FilesOption(key, default, title, description, required, allowedExtensions, validator)
+
+/**
+ * Create a new [FilesOption] and add it to the current [PatchBuilder].
+ */
+fun PatchBuilder<*>.filesOption(
+    key: String,
+    default: List<String>? = null,
+    title: String? = null,
+    description: String? = null,
+    required: Boolean = false,
+    allowedExtensions: List<String>? = null,
+    validator: Option<List<String>>.(List<String>?) -> Boolean = { true },
+): FilesOption = app.morphe.patcher.patch.filesOption(
+    key, default, title, description, required, allowedExtensions, validator,
+).also { it() }
+
+/**
+ * Create a new [ImageOption].
+ */
+fun imageOption(
+    key: String,
+    default: String? = null,
+    title: String? = null,
+    description: String? = null,
+    required: Boolean = false,
+    allowedExtensions: List<String>? = listOf("png", "jpg", "jpeg", "webp"),
+    recommendedSize: ImageSize? = null,
+    validator: Option<String>.(String?) -> Boolean = { true },
+) = ImageOption(key, default, title, description, required, allowedExtensions, recommendedSize, validator)
+
+/**
+ * Create a new [ImageOption] and add it to the current [PatchBuilder].
+ */
+fun PatchBuilder<*>.imageOption(
+    key: String,
+    default: String? = null,
+    title: String? = null,
+    description: String? = null,
+    required: Boolean = false,
+    allowedExtensions: List<String>? = listOf("png", "jpg", "jpeg", "webp"),
+    recommendedSize: ImageSize? = null,
+    validator: Option<String>.(String?) -> Boolean = { true },
+): ImageOption = app.morphe.patcher.patch.imageOption(
+    key, default, title, description, required, allowedExtensions, recommendedSize, validator,
+).also { it() }
+
+/**
+ * Create a new [ColorOption].
+ */
+fun colorOption(
+    key: String,
+    default: String? = null,
+    values: Map<String, String?>? = null,
+    title: String? = null,
+    description: String? = null,
+    required: Boolean = false,
+    validator: Option<String>.(String?) -> Boolean = { true },
+) = ColorOption(key, default, values, title, description, required, validator)
+
+/**
+ * Create a new [ColorOption] and add it to the current [PatchBuilder].
+ */
+fun PatchBuilder<*>.colorOption(
+    key: String,
+    default: String? = null,
+    values: Map<String, String?>? = null,
+    title: String? = null,
+    description: String? = null,
+    required: Boolean = false,
+    validator: Option<String>.(String?) -> Boolean = { true },
+): ColorOption = app.morphe.patcher.patch.colorOption(
+    key, default, values, title, description, required, validator,
+).also { it() }
+
+// endregion

--- a/src/test/kotlin/app/morphe/patcher/patch/options/PathOptionsTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/patch/options/PathOptionsTest.kt
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patcher
+ */
+
+package app.morphe.patcher.patch.options
+
+import app.morphe.patcher.patch.ColorOption
+import app.morphe.patcher.patch.FilePathOption
+import app.morphe.patcher.patch.FilesOption
+import app.morphe.patcher.patch.FolderOption
+import app.morphe.patcher.patch.ImageOption
+import app.morphe.patcher.patch.ImageSize
+import app.morphe.patcher.patch.Option
+import app.morphe.patcher.patch.StringOption
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.patch.colorOption
+import app.morphe.patcher.patch.filePathOption
+import app.morphe.patcher.patch.filesOption
+import app.morphe.patcher.patch.folderOption
+import app.morphe.patcher.patch.imageOption
+import app.morphe.patcher.patch.stringOption
+import kotlin.reflect.typeOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+internal object PathOptionsTest {
+    private val pathPatch = bytecodePatch(default = true) {
+        folderOption("outputFolder", default = "/sdcard/Morphe", description = "Output folder")
+        filePathOption(
+            "customApk",
+            description = "Custom APK",
+            allowedExtensions = listOf("apk"),
+        )
+        filesOption(
+            "extraDex",
+            default = listOf("/a.dex"),
+            allowedExtensions = listOf("dex"),
+        )
+        imageOption(
+            "customIcon",
+            description = "Custom icon",
+            recommendedSize = ImageSize(512, 512),
+        )
+        colorOption(
+            "accentColor",
+            default = "#FF00AA",
+            values = mapOf("Purple" to "#8B5CF6", "Red" to "#EF4444"),
+        )
+
+        // Legacy StringOption used for a path - must NOT be recognized as FolderOption.
+        stringOption("legacyPath", "/sdcard/old", description = "Path to icon folder")
+    }
+
+    @Test
+    fun `folderOption is a FolderOption subclass`() {
+        val option = pathPatch.options["outputFolder"]
+        assertIs<FolderOption>(option)
+        assertEquals("/sdcard/Morphe", option.default)
+        assertEquals(typeOf<String>(), option.type)
+    }
+
+    @Test
+    fun `filePathOption carries allowedExtensions`() {
+        val option = pathPatch.options["customApk"]
+        assertIs<FilePathOption>(option)
+        assertEquals(listOf("apk"), option.allowedExtensions)
+    }
+
+    @Test
+    fun `filesOption stores List of String and default`() {
+        val option = pathPatch.options["extraDex"]
+        assertIs<FilesOption>(option)
+        assertEquals(listOf("/a.dex"), option.default)
+        assertEquals(listOf("dex"), option.allowedExtensions)
+        assertEquals(typeOf<List<String>>(), option.type)
+    }
+
+    @Test
+    fun `imageOption carries recommendedSize and default allowedExtensions`() {
+        val option = pathPatch.options["customIcon"]
+        assertIs<ImageOption>(option)
+        assertEquals(ImageSize(512, 512), option.recommendedSize)
+        assertNotNull(option.allowedExtensions)
+        assertTrue("png" in option.allowedExtensions)
+    }
+
+    @Test
+    fun `colorOption stores presets via values map`() {
+        val option = pathPatch.options["accentColor"]
+        assertIs<ColorOption>(option)
+        assertEquals("#FF00AA", option.default)
+        assertEquals("#8B5CF6", option.values?.get("Purple"))
+    }
+
+    @Test
+    fun `legacy stringOption is NOT auto-promoted to a typed subclass`() {
+        val option = pathPatch.options["legacyPath"]
+        assertTrue(option !is FolderOption, "stringOption must not be promoted to FolderOption")
+        assertTrue(option !is FilePathOption, "stringOption must not be promoted to FilePathOption")
+        assertTrue(option !is ImageOption, "stringOption must not be promoted to ImageOption")
+        assertTrue(option !is ColorOption, "stringOption must not be promoted to ColorOption")
+        assertIs<Option<*>>(option)
+        assertEquals(typeOf<String>(), option.type)
+    }
+
+    @Test
+    fun `stringOption returns a StringOption instance`() {
+        assertIs<StringOption>(pathPatch.options["legacyPath"])
+        assertIs<StringOption>(stringOption("standalone"))
+    }
+
+    @Test
+    fun `typed options are also StringOptions (backward compat with old consumers)`() {
+        assertIs<StringOption>(pathPatch.options["outputFolder"])   // FolderOption
+        assertIs<StringOption>(pathPatch.options["customApk"])      // FilePathOption
+        assertIs<StringOption>(pathPatch.options["customIcon"])     // ImageOption
+        assertIs<StringOption>(pathPatch.options["accentColor"])    // ColorOption
+        // FilesOption stores List<String>, so it's NOT a StringOption
+        assertTrue(pathPatch.options["extraDex"] !is StringOption)
+    }
+
+    @Test
+    fun `StringOption exposes file helper`() {
+        val opt = pathPatch.options["outputFolder"] as FolderOption
+        opt.reset()   // isolate from other tests mutating the shared patch
+        assertNotNull(opt.file)
+        assertEquals("/sdcard/Morphe", opt.file!!.path.replace('\\', '/'))
+        assertNotNull(opt.directory)                 // alias
+        assertEquals(opt.file, opt.directory)
+        // Blank / null → null
+        pathPatch.options["outputFolder"] = null
+        assertNull((pathPatch.options["outputFolder"] as FolderOption).file)
+    }
+
+    @Test
+    fun `FilesOption exposes files helper`() {
+        val opt = pathPatch.options["extraDex"] as FilesOption
+        val files = opt.files
+        assertNotNull(files)
+        assertEquals(1, files.size)
+        assertEquals("/a.dex", files[0].path.replace('\\', '/'))
+    }
+
+    @Test
+    fun `ColorOption parses hex to ARGB int`() {
+        val opt = pathPatch.options["accentColor"] as ColorOption
+        opt.reset()   // isolate from other tests mutating the shared patch
+        // Default "#FF00AA" (RGB) → alpha assumed FF → 0xFFFF00AA (which as signed Int is negative)
+        assertEquals(0xFFFF00AA.toInt(), opt.colorInt)
+
+        pathPatch.options["accentColor"] = "#80112233"      // AARRGGBB
+        assertEquals(0x80112233.toInt(), opt.colorInt)
+
+        pathPatch.options["accentColor"] = "@android:color/black" // resource ref
+        assertNull(opt.colorInt)
+
+        pathPatch.options["accentColor"] = null
+        assertNull(opt.colorInt)
+    }
+
+    @Test
+    fun `Map-based setOptions API still works for a ColorOption`() {
+        val option = pathPatch.options["accentColor"]
+        // Setting via the polymorphic Options API stores the raw String value.
+        pathPatch.options["accentColor"] = "#000000"
+        assertEquals("#000000", option.value)
+    }
+
+    @Test
+    fun `standalone builders return the correct subclass`() {
+        assertIs<FolderOption>(folderOption("x"))
+        assertIs<FilePathOption>(filePathOption("x"))
+        assertIs<FilesOption>(filesOption("x"))
+        assertIs<ImageOption>(imageOption("x"))
+        assertIs<ColorOption>(colorOption("x"))
+    }
+
+    @Test
+    fun `option value defaults are honoured on typed subclasses`() {
+        val opt = pathPatch.options["outputFolder"] as FolderOption
+        assertEquals("/sdcard/Morphe", opt.value)
+        opt.reset()
+        assertEquals("/sdcard/Morphe", opt.value)
+        pathPatch.options["outputFolder"] = null
+        assertNull(opt.value)
+    }
+}


### PR DESCRIPTION
Adds typed patch options (folder, file, image, color) so editors dispatch on type rather than description-based heuristics. Existing `stringOption` bundles keep working unchanged.

  **Related PRs:**
  - morphe-patcher https://github.com/MorpheApp/morphe-patcher/pull/152
  - morphe-manager https://github.com/MorpheApp/morphe-manager/pull/706
  - morphe-patches https://github.com/MorpheApp/morphe-patches/pull/1971