### PR TITLE
feat: Add patch availability

### DIFF
--- a/api/morphe-patcher.api
+++ b/api/morphe-patcher.api
@@ -536,6 +536,17 @@ public final class app/morphe/patcher/logging/NoOpLogger : app/morphe/patcher/lo
 	public fun log (Lapp/morphe/patcher/logging/LogLevel;Ljava/lang/String;)V
 }
 
+public final class app/morphe/patcher/patch/ApkArchitecture : java/lang/Enum {
+	public static final field ARM64_V8A Lapp/morphe/patcher/patch/ApkArchitecture;
+	public static final field ARMEABI_V7A Lapp/morphe/patcher/patch/ApkArchitecture;
+	public static final field UNIVERSAL Lapp/morphe/patcher/patch/ApkArchitecture;
+	public static final field X86 Lapp/morphe/patcher/patch/ApkArchitecture;
+	public static final field X86_64 Lapp/morphe/patcher/patch/ApkArchitecture;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lapp/morphe/patcher/patch/ApkArchitecture;
+	public static fun values ()[Lapp/morphe/patcher/patch/ApkArchitecture;
+}
+
 public final class app/morphe/patcher/patch/ApkFileType : java/lang/Enum {
 	public static final field APK Lapp/morphe/patcher/patch/ApkFileType;
 	public static final field APKM Lapp/morphe/patcher/patch/ApkFileType;
@@ -696,6 +707,15 @@ public final class app/morphe/patcher/patch/ImageSize {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class app/morphe/patcher/patch/InstallerType : java/lang/Enum {
+	public static final field MOUNT Lapp/morphe/patcher/patch/InstallerType;
+	public static final field SHIZUKU Lapp/morphe/patcher/patch/InstallerType;
+	public static final field STANDARD Lapp/morphe/patcher/patch/InstallerType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lapp/morphe/patcher/patch/InstallerType;
+	public static fun values ()[Lapp/morphe/patcher/patch/InstallerType;
+}
+
 public class app/morphe/patcher/patch/Option {
 	public fun <init> (Ljava/lang/String;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;ZLkotlin/reflect/KType;Lkotlin/jvm/functions/Function2;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;ZLkotlin/reflect/KType;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -822,10 +842,12 @@ public final class app/morphe/patcher/patch/Options : java/util/Map, kotlin/jvm/
 }
 
 public abstract class app/morphe/patcher/patch/Patch {
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/util/List;Ljava/util/Set;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/util/List;Ljava/util/Set;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/util/List;Ljava/util/Set;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/util/Set;Ljava/util/Set;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun execute (Lapp/morphe/patcher/patch/PatchContext;)V
 	public final fun finalize (Lapp/morphe/patcher/patch/PatchContext;)V
+	public final fun getAvailability ()Lkotlin/jvm/functions/Function2;
 	public final fun getCompatibility ()Ljava/util/List;
 	public final fun getCompatiblePackages ()Ljava/util/Set;
 	public final fun getDefault ()Z
@@ -837,14 +859,30 @@ public abstract class app/morphe/patcher/patch/Patch {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class app/morphe/patcher/patch/PatchAvailability : java/lang/Enum {
+	public static final field DISABLED Lapp/morphe/patcher/patch/PatchAvailability;
+	public static final field ENABLED Lapp/morphe/patcher/patch/PatchAvailability;
+	public static final field REQUIRED Lapp/morphe/patcher/patch/PatchAvailability;
+	public static final field UNAVAILABLE Lapp/morphe/patcher/patch/PatchAvailability;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lapp/morphe/patcher/patch/PatchAvailability;
+	public static fun values ()[Lapp/morphe/patcher/patch/PatchAvailability;
+}
+
+public final class app/morphe/patcher/patch/PatchAvailabilityKt {
+	public static final fun defaultAvailability (Z)Lkotlin/jvm/functions/Function2;
+}
+
 public abstract class app/morphe/patcher/patch/PatchBuilder {
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun availability (Lkotlin/jvm/functions/Function2;)V
 	public final fun compatibleWith ([Lapp/morphe/patcher/patch/Compatibility;)V
 	public final fun compatibleWith ([Ljava/lang/String;)V
 	public final fun compatibleWith ([Lkotlin/Pair;)V
 	public final fun dependsOn ([Lapp/morphe/patcher/patch/Patch;)V
 	public final fun execute (Lkotlin/jvm/functions/Function1;)V
 	public final fun finalize (Lkotlin/jvm/functions/Function1;)V
+	protected final fun getAvailability ()Lkotlin/jvm/functions/Function2;
 	protected final fun getCompatibility ()Ljava/util/List;
 	protected final fun getCompatiblePackages ()Ljava/util/Set;
 	protected final fun getDefault ()Z
@@ -858,6 +896,7 @@ public abstract class app/morphe/patcher/patch/PatchBuilder {
 	protected final fun getUse ()Z
 	public final fun invoke (Lapp/morphe/patcher/patch/Option;)Lapp/morphe/patcher/patch/Option;
 	public final fun invoke (Ljava/lang/String;[Ljava/lang/String;)Lkotlin/Pair;
+	protected final fun setAvailability (Lkotlin/jvm/functions/Function2;)V
 	protected final fun setCompatibility (Ljava/util/List;)V
 	protected final fun setCompatiblePackages (Ljava/util/Set;)V
 	protected final fun setDependencies (Ljava/util/Set;)V

--- a/api/morphe-patcher.api
+++ b/api/morphe-patcher.api
@@ -594,6 +594,10 @@ public final class app/morphe/patcher/patch/AppTarget : java/lang/Comparable {
 	public fun toString ()Ljava/lang/String;
 }
 
+public abstract interface class app/morphe/patcher/patch/AvailabilityResolver {
+	public abstract fun resolve (Lapp/morphe/patcher/patch/InstallerType;Lapp/morphe/patcher/patch/ApkArchitecture;)Lapp/morphe/patcher/patch/PatchAvailability;
+}
+
 public final class app/morphe/patcher/patch/BytecodePatch : app/morphe/patcher/patch/Patch {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/util/Set;Ljava/util/Set;Ljava/util/function/Supplier;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/util/Set;Ljava/util/Set;Ljava/util/function/Supplier;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
@@ -842,12 +846,12 @@ public final class app/morphe/patcher/patch/Options : java/util/Map, kotlin/jvm/
 }
 
 public abstract class app/morphe/patcher/patch/Patch {
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/util/List;Ljava/util/Set;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/util/List;Ljava/util/Set;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/util/List;Ljava/util/Set;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lapp/morphe/patcher/patch/AvailabilityResolver;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/util/List;Ljava/util/Set;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lapp/morphe/patcher/patch/AvailabilityResolver;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/util/Set;Ljava/util/Set;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun execute (Lapp/morphe/patcher/patch/PatchContext;)V
 	public final fun finalize (Lapp/morphe/patcher/patch/PatchContext;)V
-	public final fun getAvailability ()Lkotlin/jvm/functions/Function2;
+	public final fun getAvailability ()Lapp/morphe/patcher/patch/AvailabilityResolver;
 	public final fun getCompatibility ()Ljava/util/List;
 	public final fun getCompatiblePackages ()Ljava/util/Set;
 	public final fun getDefault ()Z
@@ -870,19 +874,19 @@ public final class app/morphe/patcher/patch/PatchAvailability : java/lang/Enum {
 }
 
 public final class app/morphe/patcher/patch/PatchAvailabilityKt {
-	public static final fun defaultAvailability (Z)Lkotlin/jvm/functions/Function2;
+	public static final fun defaultAvailability (Z)Lapp/morphe/patcher/patch/AvailabilityResolver;
 }
 
 public abstract class app/morphe/patcher/patch/PatchBuilder {
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun availability (Lkotlin/jvm/functions/Function2;)V
+	public final fun availability (Lapp/morphe/patcher/patch/AvailabilityResolver;)V
 	public final fun compatibleWith ([Lapp/morphe/patcher/patch/Compatibility;)V
 	public final fun compatibleWith ([Ljava/lang/String;)V
 	public final fun compatibleWith ([Lkotlin/Pair;)V
 	public final fun dependsOn ([Lapp/morphe/patcher/patch/Patch;)V
 	public final fun execute (Lkotlin/jvm/functions/Function1;)V
 	public final fun finalize (Lkotlin/jvm/functions/Function1;)V
-	protected final fun getAvailability ()Lkotlin/jvm/functions/Function2;
+	protected final fun getAvailability ()Lapp/morphe/patcher/patch/AvailabilityResolver;
 	protected final fun getCompatibility ()Ljava/util/List;
 	protected final fun getCompatiblePackages ()Ljava/util/Set;
 	protected final fun getDefault ()Z
@@ -896,7 +900,7 @@ public abstract class app/morphe/patcher/patch/PatchBuilder {
 	protected final fun getUse ()Z
 	public final fun invoke (Lapp/morphe/patcher/patch/Option;)Lapp/morphe/patcher/patch/Option;
 	public final fun invoke (Ljava/lang/String;[Ljava/lang/String;)Lkotlin/Pair;
-	protected final fun setAvailability (Lkotlin/jvm/functions/Function2;)V
+	protected final fun setAvailability (Lapp/morphe/patcher/patch/AvailabilityResolver;)V
 	protected final fun setCompatibility (Ljava/util/List;)V
 	protected final fun setCompatiblePackages (Ljava/util/Set;)V
 	protected final fun setDependencies (Ljava/util/Set;)V

--- a/src/main/kotlin/app/morphe/patcher/patch/Patch.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/Patch.kt
@@ -15,7 +15,6 @@ import java.net.URLClassLoader
 import java.nio.file.Files
 import java.util.function.Supplier
 import java.util.jar.JarFile
-import java.util.logging.Logger
 
 @Deprecated("Use Compatibility instead")
 typealias PackageName = String
@@ -39,6 +38,8 @@ typealias Package = Pair<PackageName, Set<VersionName>?>
  * @param executeBlock The execution block of the patch.
  * @param finalizeBlock The finalizing block of the patch. Called after all patches have been executed,
  * in reverse order of execution.
+ * @param availability Optional resolver that decides the patch's [PatchAvailability] for a given
+ *   [InstallerType] and [ApkArchitecture]. When null, callers should fall back to [default].
  *
  * @constructor Create a new patch.
  */
@@ -53,6 +54,10 @@ sealed class Patch<C : PatchContext<*>>(
     // Must be internal and nullable, so that Patcher.invoke can check,
     // if a patch has a finalizing block in order to not emit it twice.
     internal var finalizeBlock: ((C) -> Unit)?,
+    // Additive field. Trailing position with a default keeps binary compatibility for existing
+    // pre-compiled patch bundles: they call the previous constructor arity, and Kotlin generates
+    // an overload that fills this in as null.
+    val availability: AvailabilityResolver? = null,
 ) {
 
     @Deprecated("Use constructor with Compatibility object")
@@ -186,6 +191,7 @@ class BytecodePatch internal constructor(
     internal val extensionStreamProviders: List<Supplier<out Iterable<Supplier<InputStream>>>>,
     executeBlock: (BytecodePatchContext) -> Unit,
     finalizeBlock: ((BytecodePatchContext) -> Unit)?,
+    availability: AvailabilityResolver? = null,
 ) : Patch<BytecodePatchContext>(
     name,
     description,
@@ -195,6 +201,7 @@ class BytecodePatch internal constructor(
     options,
     executeBlock,
     finalizeBlock,
+    availability,
 ) {
 
     @Deprecated("Use constructor with extensionInputStreams parameter")
@@ -283,6 +290,7 @@ class RawResourcePatch internal constructor(
     options: Set<Option<*>>,
     executeBlock: (ResourcePatchContext) -> Unit,
     finalizeBlock: ((ResourcePatchContext) -> Unit)?,
+    availability: AvailabilityResolver? = null,
 ) : Patch<ResourcePatchContext>(
     name,
     description,
@@ -292,6 +300,7 @@ class RawResourcePatch internal constructor(
     options,
     executeBlock,
     finalizeBlock,
+    availability,
 ) {
 
     @Deprecated("Use constructor with Compatibility object")
@@ -348,6 +357,7 @@ class ResourcePatch internal constructor(
     options: Set<Option<*>>,
     executeBlock: (ResourcePatchContext) -> Unit,
     finalizeBlock: ((ResourcePatchContext) -> Unit)?,
+    availability: AvailabilityResolver? = null,
 ) : Patch<ResourcePatchContext>(
     name,
     description,
@@ -357,6 +367,7 @@ class ResourcePatch internal constructor(
     options,
     executeBlock,
     finalizeBlock,
+    availability,
 ) {
 
     @Deprecated("Use constructor with Compatibility object")
@@ -415,6 +426,7 @@ sealed class PatchBuilder<C : PatchContext<*>>(
 
     protected var executeBlock: ((C) -> Unit) = { }
     protected var finalizeBlock: ((C) -> Unit)? = null
+    protected var availability: AvailabilityResolver? = null
 
     @Deprecated(
         message = "Use 'default' instead of 'use'",
@@ -527,6 +539,21 @@ sealed class PatchBuilder<C : PatchContext<*>>(
      */
     fun finalize(block: C.() -> Unit) {
         finalizeBlock = block
+    }
+
+    /**
+     * Declare how this patch behaves for a given install target.
+     *
+     * The [block] receives the [InstallerType] and [ApkArchitecture] chosen by the caller and
+     * returns a [PatchAvailability]. It runs off the patching hot path (before execute), so it
+     * must be pure and cheap. Patches that do not call [availability] fall back to their
+     * [default] flag.
+     *
+     * @param block Resolver evaluated by the caller (Manager / CLI) before patch selection is
+     *   finalized.
+     */
+    fun availability(block: AvailabilityResolver) {
+        availability = block
     }
 
     internal fun resolveDefaultValue(): Boolean {
@@ -648,7 +675,8 @@ class BytecodePatchBuilder internal constructor(
             addAll(extensionStreamProviders)
         },
         executeBlock = executeBlock,
-        finalizeBlock = finalizeBlock
+        finalizeBlock = finalizeBlock,
+        availability = availability,
     )
 }
 
@@ -694,6 +722,7 @@ class RawResourcePatchBuilder internal constructor(
         options,
         executeBlock,
         finalizeBlock,
+        availability,
     )
 }
 
@@ -739,6 +768,7 @@ class ResourcePatchBuilder internal constructor(
         options,
         executeBlock,
         finalizeBlock,
+        availability,
     )
 }
 

--- a/src/main/kotlin/app/morphe/patcher/patch/PatchAvailability.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/PatchAvailability.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patcher
+ */
+
+package app.morphe.patcher.patch
+
+/**
+ * The kind of install target the patched app is being produced for.
+ *
+ * Patches use this together with [ApkArchitecture] to declare whether they are
+ * available, forbidden or required for a given install target, via [AvailabilityResolver].
+ *
+ * Callers (Manager / CLI) are responsible for translating their own installer taxonomy
+ * (session install, mount install, Shizuku, etc.) into one of these values before
+ * asking a patch about its availability.
+ */
+enum class InstallerType {
+    /** A regular session-based install. GmsCore is required for Google apps. */
+    STANDARD,
+
+    /** A root install performed by bind-mounting the patched APK over the original. */
+    MOUNT,
+
+    /**
+     * An elevated non-root install performed via Shizuku. Behaves like [STANDARD]
+     * for most patches; separated so a patch can differentiate if needed.
+     */
+    SHIZUKU,
+}
+
+/**
+ * The primary architecture of the target APK the patched app is being produced for.
+ *
+ * Passed to [AvailabilityResolver] together with [InstallerType]. When the input APK
+ * bundles multiple ABIs, callers should pass the highest-priority ABI actually present,
+ * or [UNIVERSAL] when the APK targets all ABIs.
+ */
+enum class ApkArchitecture {
+    ARM64_V8A,
+    ARMEABI_V7A,
+    X86_64,
+    X86,
+    UNIVERSAL,
+}
+
+/**
+ * How a patch should behave for a given (installer, architecture) combination.
+ *
+ * A patch that does not declare an [AvailabilityResolver] is treated as [ENABLED] when
+ * its `default` flag is true and [DISABLED] otherwise, preserving legacy behavior.
+ */
+enum class PatchAvailability {
+    /** Enabled by default. The user may disable it. */
+    ENABLED,
+
+    /** Disabled by default. The user may enable it. */
+    DISABLED,
+
+    /** Force-included. The user cannot remove it. */
+    REQUIRED,
+
+    /** Force-excluded. The user cannot add it. */
+    UNAVAILABLE,
+}
+
+/**
+ * A pure function stored on a patch that decides the patch's [PatchAvailability]
+ * for a given ([InstallerType], [ApkArchitecture]) combination.
+ *
+ * Kept as a lambda (rather than static fields) so a single patch can express
+ * matrix-like rules without inflating the metadata surface.
+ *
+ * Implementations must be side-effect free and deterministic. Manager and CLI may call
+ * them repeatedly while the user changes selection or install mode.
+ */
+typealias AvailabilityResolver = (InstallerType, ApkArchitecture) -> PatchAvailability
+
+/**
+ * Returns an [AvailabilityResolver] that ignores its inputs and derives the result
+ * purely from a static [default] flag. Provided as a convenience for patches that
+ * want to opt into the new API without adding target-specific logic.
+ */
+fun defaultAvailability(default: Boolean): AvailabilityResolver = { _, _ ->
+    if (default) PatchAvailability.ENABLED else PatchAvailability.DISABLED
+}

--- a/src/main/kotlin/app/morphe/patcher/patch/PatchAvailability.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/PatchAvailability.kt
@@ -65,22 +65,19 @@ enum class PatchAvailability {
 }
 
 /**
- * A pure function stored on a patch that decides the patch's [PatchAvailability]
- * for a given ([InstallerType], [ApkArchitecture]) combination.
+ * Decides a patch's [PatchAvailability] for a given install target.
  *
- * Kept as a lambda (rather than static fields) so a single patch can express
- * matrix-like rules without inflating the metadata surface.
- *
- * Implementations must be side-effect free and deterministic. Manager and CLI may call
- * them repeatedly while the user changes selection or install mode.
+ * Implementations must be pure and deterministic. Callers may invoke [resolve] repeatedly
+ * while the user changes selection or install mode.
  */
-typealias AvailabilityResolver = (InstallerType, ApkArchitecture) -> PatchAvailability
+fun interface AvailabilityResolver {
+    fun resolve(installer: InstallerType, arch: ApkArchitecture): PatchAvailability
+}
 
 /**
- * Returns an [AvailabilityResolver] that ignores its inputs and derives the result
- * purely from a static [default] flag. Provided as a convenience for patches that
- * want to opt into the new API without adding target-specific logic.
+ * An [AvailabilityResolver] that ignores its inputs and reports [PatchAvailability.ENABLED]
+ * when [default] is true, [PatchAvailability.DISABLED] otherwise.
  */
-fun defaultAvailability(default: Boolean): AvailabilityResolver = { _, _ ->
+fun defaultAvailability(default: Boolean) = AvailabilityResolver { _, _ ->
     if (default) PatchAvailability.ENABLED else PatchAvailability.DISABLED
 }


### PR DESCRIPTION
### Description

Adds a per-patch `availability { installerType, apkArchitecture -> ... }` DSL so patches declare `ENABLED` / `DISABLED` / `REQUIRED` / `UNAVAILABLE` per install target, replacing the hardcoded `GmsCore support` filter in Manager and letting third-party patches restrict themselves to root or non-root.

**Related PRs:**
- https://github.com/MorpheApp/morphe-patcher/pull/156
- https://github.com/MorpheApp/morphe-patches/pull/2155
- https://github.com/MorpheApp/morphe-manager/pull/747