### PR TITLE
perf: Avoid rebuilding unchanged APK resources

### DIFF
--- a/src/main/kotlin/app/morphe/patcher/apk/ApkUtils.kt
+++ b/src/main/kotlin/app/morphe/patcher/apk/ApkUtils.kt
@@ -33,8 +33,7 @@ object ApkUtils {
     // Alignment for all other files.
     private const val DEFAULT_ALIGNMENT = 4
 
-    // Prefix for resources.
-    private const val RES_PREFIX = "res/"
+    private val dexEntryName = Regex("""classes(?:\d+)?\.dex""")
 
     private val zFileOptions =
         ZFileOptions().setAlignmentRule(
@@ -48,38 +47,31 @@ object ApkUtils {
      * Applies the [PatcherResult] to the given [apkFile].
      *
      * The order of operation is as follows:
-     * 1. Delete all resources in the target APK.
-     * 2. Merge resources.apk compiled by AAPT.
-     * 3. Write raw resources.
-     * 4. Delete resources staged for deletion.
-     * 5. Write patched dex files.
-     * 6. Realign the APK.
+     * 1. Use resources.apk compiled by AAPT as the output base, when present.
+     * 2. Write raw resources.
+     * 3. Delete resources staged for deletion.
+     * 4. Write patched dex files.
+     * 5. Realign the APK.
      *
      * @param apkFile The file to apply the patched files to.
      */
     fun PatcherResult.applyTo(apkFile: File) {
+        resources.resourcesApk?.let { resourcesApk ->
+            logger.info("Using compiled resource APK as output base")
+
+            if (resourcesApk.canonicalFile != apkFile.canonicalFile) {
+                resourcesApk.copyTo(apkFile, overwrite = true)
+            }
+        }
+
         ZFile.openReadWrite(apkFile, zFileOptions).use { targetApkZFile ->
             resources.let { resources ->
-                // Add resources compiled by AAPT.
-                resources.resourcesApk?.let { resourcesApk ->
-                    ZFile.openReadOnly(resourcesApk).use { resourcesApkZFile ->
-                        // Delete all resources in the target APK before merging the new ones.
-                        // This is necessary because the resources.apk renames resources.
-                        // So unless, the old resources are deleted, there will be orphaned resources in the APK.
-                        // It is not necessary, but for the sake of cleanliness, it is done.
-                        targetApkZFile.entries().filter { entry ->
-                            entry.centralDirectoryHeader.name.startsWith(RES_PREFIX)
-                        }.forEach(StoredEntry::delete)
-
-                        targetApkZFile.mergeFrom(resourcesApkZFile) { entry ->
-                            // Filter any dex files in case they were packaged inside resources.apk for some reason.
-                            (entry.startsWith("classes") && entry.endsWith(".dex"))
-
-                            // Filter any files that are already marked for deletion so we don't needlessly copy them,
-                            // in case they made it into the resources.apk.
-                            || entry in resources.deleteResources
-                        }
-                    }
+                // A compiled resource APK is a complete non-DEX APK. Remove any accidentally packaged DEX files
+                // before adding the final patched DEX set.
+                if (resources.resourcesApk != null) {
+                    targetApkZFile.entries().filter { entry ->
+                        entry.centralDirectoryHeader.name.matches(dexEntryName)
+                    }.forEach(StoredEntry::delete)
                 }
 
                 // Add resources not compiled by AAPT.
@@ -98,9 +90,14 @@ object ApkUtils {
             }
 
             // Run this after resource updates to ensure our dex files don't get overwritten.
-            dexFiles.forEach { dexFile ->
-                targetApkZFile.add(dexFile.name, dexFile.stream)
-                dexFile.stream.close()
+            try {
+                dexFiles.forEach { dexFile ->
+                    targetApkZFile.add(dexFile.name, dexFile.stream)
+                }
+            } finally {
+                dexFiles.forEach { dexFile ->
+                    runCatching { dexFile.stream.close() }
+                }
             }
 
             logger.info("Aligning APK")

--- a/src/main/kotlin/app/morphe/patcher/apk/ApkUtils.kt
+++ b/src/main/kotlin/app/morphe/patcher/apk/ApkUtils.kt
@@ -33,8 +33,7 @@ object ApkUtils {
     // Alignment for all other files.
     private const val DEFAULT_ALIGNMENT = 4
 
-    // Prefix for resources.
-    private const val RES_PREFIX = "res/"
+    private val dexEntryName = Regex("""classes(?:\d+)?\.dex""")
 
     private val zFileOptions =
         ZFileOptions().setAlignmentRule(
@@ -48,12 +47,11 @@ object ApkUtils {
      * Applies the [PatcherResult] to the given [apkFile].
      *
      * The order of operation is as follows:
-     * 1. Delete all resources in the target APK.
-     * 2. Merge resources.apk compiled by AAPT.
-     * 3. Write raw resources.
-     * 4. Delete resources staged for deletion.
-     * 5. Write patched dex files.
-     * 6. Realign the APK.
+     * 1. Use resources.apk compiled by AAPT as the output base, when present.
+     * 2. Write raw resources.
+     * 3. Delete resources staged for deletion.
+     * 4. Write patched dex files.
+     * 5. Realign the APK.
      *
      * [apkFile] must be a copy of the APK that was patched. The result is a set of changes
      * against that APK rather than a self-contained APK: entries a patch did not touch, such as
@@ -64,28 +62,22 @@ object ApkUtils {
      * @param apkFile A copy of the patched APK, to apply the patched files to.
      */
     fun PatcherResult.applyTo(apkFile: File) {
+        resources.resourcesApk?.let { resourcesApk ->
+            logger.info("Using compiled resource APK as output base")
+
+            if (resourcesApk.canonicalFile != apkFile.canonicalFile) {
+                resourcesApk.copyTo(apkFile, overwrite = true)
+            }
+        }
+
         ZFile.openReadWrite(apkFile, zFileOptions).use { targetApkZFile ->
             resources.let { resources ->
-                // Add resources compiled by AAPT.
-                resources.resourcesApk?.let { resourcesApk ->
-                    ZFile.openReadOnly(resourcesApk).use { resourcesApkZFile ->
-                        // Delete all resources in the target APK before merging the new ones.
-                        // This is necessary because the resources.apk renames resources.
-                        // So unless, the old resources are deleted, there will be orphaned resources in the APK.
-                        // It is not necessary, but for the sake of cleanliness, it is done.
-                        targetApkZFile.entries().filter { entry ->
-                            entry.centralDirectoryHeader.name.startsWith(RES_PREFIX)
-                        }.forEach(StoredEntry::delete)
-
-                        targetApkZFile.mergeFrom(resourcesApkZFile) { entry ->
-                            // Filter any dex files in case they were packaged inside resources.apk for some reason.
-                            (entry.startsWith("classes") && entry.endsWith(".dex"))
-
-                            // Filter any files that are already marked for deletion so we don't needlessly copy them,
-                            // in case they made it into the resources.apk.
-                            || entry in resources.deleteResources
-                        }
-                    }
+                // A compiled resource APK is a complete non-DEX APK. Remove any accidentally packaged DEX files
+                // before adding the final patched DEX set.
+                if (resources.resourcesApk != null) {
+                    targetApkZFile.entries().filter { entry ->
+                        entry.centralDirectoryHeader.name.matches(dexEntryName)
+                    }.forEach(StoredEntry::delete)
                 }
 
                 // Add resources not compiled by AAPT.
@@ -104,9 +96,14 @@ object ApkUtils {
             }
 
             // Run this after resource updates to ensure our dex files don't get overwritten.
-            dexFiles.forEach { dexFile ->
-                targetApkZFile.add(dexFile.name, dexFile.stream)
-                dexFile.stream.close()
+            try {
+                dexFiles.forEach { dexFile ->
+                    targetApkZFile.add(dexFile.name, dexFile.stream)
+                }
+            } finally {
+                dexFiles.forEach { dexFile ->
+                    runCatching { dexFile.stream.close() }
+                }
             }
 
             logger.info("Aligning APK")

--- a/src/main/kotlin/app/morphe/patcher/apk/ApkUtils.kt
+++ b/src/main/kotlin/app/morphe/patcher/apk/ApkUtils.kt
@@ -53,11 +53,8 @@ object ApkUtils {
      * 4. Write patched dex files.
      * 5. Realign the APK.
      *
-     * [apkFile] must be a copy of the APK that was patched. The result is a set of changes
-     * against that APK rather than a self-contained APK: entries a patch did not touch, such as
-     * native libraries and assets, are expected to already be present in [apkFile] and are not
-     * carried in the result. Applying this to any other file silently produces an APK missing
-     * those entries.
+     * Without a compiled resource APK, [apkFile] must be a copy of the input APK so that
+     * unchanged entries remain available. Otherwise, the compiled resource APK replaces it.
      *
      * @param apkFile A copy of the patched APK, to apply the patched files to.
      */

--- a/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
@@ -38,8 +38,10 @@ import org.w3c.dom.Element
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.attribute.FileTime
 import java.util.logging.Logger
-import kotlin.time.measureTimedValue
+import kotlin.time.measureTime
 
 internal class ArsclibResourceCoder(
     internal val workingDir: File,
@@ -62,10 +64,16 @@ internal class ArsclibResourceCoder(
     internal val deletedFiles = mutableSetOf<String>()
 
     /**
-     * Snapshot of file metadata (modification time and size) captured after decoding resources.
-     * Used to detect which files were added or modified between decoding and encoding.
+     * Snapshot of file metadata and identity captured after decoding resources.
+     * High-resolution timestamps and file keys catch same-size rewrites and replacement files without rereading every
+     * decoded resource payload.
      */
-    internal data class FileSnapshot(val lastModified: Long, val size: Long)
+    internal class FileSnapshot(
+        val creationTime: FileTime,
+        val lastModified: FileTime,
+        val size: Long,
+        val fileKey: Any?,
+    )
     internal var fileSnapshotCache: Map<File, FileSnapshot> = emptyMap()
     internal var pathMap: PathMap = PathMap.EMPTY
 
@@ -75,10 +83,10 @@ internal class ArsclibResourceCoder(
     internal fun buildFileSnapshot(): Map<File, FileSnapshot> {
         val snapshot = mutableMapOf<File, FileSnapshot>()
         workingDir.resolve("resources").walkTopDown().filter { it.isFile }.forEach { file ->
-            snapshot[file] = FileSnapshot(file.lastModified(), file.length())
+            snapshot[file] = file.snapshot()
         }
         workingDir.resolve("root").walkTopDown().filter { it.isFile }.forEach { file ->
-            snapshot[file] = FileSnapshot(file.lastModified(), file.length())
+            snapshot[file] = file.snapshot()
         }
         return snapshot
     }
@@ -98,7 +106,7 @@ internal class ArsclibResourceCoder(
                 if (excludedPaths.contains(relativePath)) return@forEach
 
                 val cached = fileSnapshotCache[file]
-                if (cached == null || file.lastModified() != cached.lastModified || file.length() != cached.size) {
+                if (file.differsFrom(cached)) {
                     modifiedResResources.add(file)
                 }
             }
@@ -106,7 +114,7 @@ internal class ArsclibResourceCoder(
 
         otherResourcesRootDirectory.walkTopDown().filter { it.isFile }.forEach { file ->
             val cached = fileSnapshotCache[file]
-            if (cached == null || file.lastModified() != cached.lastModified || file.length() != cached.size) {
+            if (file.differsFrom(cached)) {
                 modifiedBinaryResources.add(file)
             }
         }
@@ -298,9 +306,9 @@ internal class ArsclibResourceCoder(
         val encoder = ApkModuleXmlEncoder()
         encoder.apkModule.use { loadedModule ->
             loadedModule.setPreferredFramework(lazyPackageInfo.value.frameworkVersion)
-            val scanDuration = measureTimedValue {
+            val scanDuration = measureTime {
                 encoder.scanDirectory(workingDir)
-            }.duration
+            }
 
             ApkModule.loadApkFile(apkFile).use { originalModule ->
                 val changedEntries = changedArchiveEntries(originalPackageName != newPackageName)
@@ -312,9 +320,9 @@ internal class ArsclibResourceCoder(
                             "rebuilding $rebuiltEntries entries",
                 )
 
-                val writeDuration = measureTimedValue {
+                val writeDuration = measureTime {
                     loadedModule.writeApk(outputApk)
-                }.duration
+                }
 
                 logger.info("Resource APK timings: scan=$scanDuration, write=$writeDuration")
             }
@@ -382,6 +390,25 @@ internal class ArsclibResourceCoder(
 
         val alias = basePath.relativize(filePath).toString().replace(File.separatorChar, '/')
         return pathMap.getOriginalName(alias) ?: alias
+    }
+
+    private fun File.snapshot(): FileSnapshot {
+        val attributes = Files.readAttributes(toPath(), BasicFileAttributes::class.java)
+        return FileSnapshot(
+            attributes.creationTime(),
+            attributes.lastModifiedTime(),
+            attributes.size(),
+            attributes.fileKey(),
+        )
+    }
+
+    private fun File.differsFrom(snapshot: FileSnapshot?): Boolean {
+        if (snapshot == null) return true
+        val attributes = Files.readAttributes(toPath(), BasicFileAttributes::class.java)
+        return attributes.creationTime() != snapshot.creationTime ||
+                attributes.lastModifiedTime() != snapshot.lastModified ||
+                attributes.size() != snapshot.size ||
+                attributes.fileKey() != snapshot.fileKey
     }
 
     override fun getOtherResourceFiles(outputDir: File, resourceMode: ResourceMode): File? {

--- a/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
@@ -65,8 +65,8 @@ internal class ArsclibResourceCoder(
 
     /**
      * Snapshot of file metadata and identity captured after decoding resources.
-     * High-resolution timestamps and file keys catch same-size rewrites and replacement files without rereading every
-     * decoded resource payload.
+     * High-resolution timestamps and file keys improve same-size change detection when the filesystem exposes
+     * distinguishable metadata, without rereading every decoded resource payload.
      */
     internal class FileSnapshot(
         val creationTime: FileTime,

--- a/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
@@ -28,6 +28,7 @@ import com.reandroid.apk.ApkModule
 import com.reandroid.apk.ApkModuleRawDecoder
 import com.reandroid.apk.ApkModuleXmlDecoder
 import com.reandroid.apk.ApkModuleXmlEncoder
+import com.reandroid.archive.InputSource
 import com.reandroid.archive.block.ApkSignatureBlock
 import com.reandroid.arsc.coder.CoderSetting
 import com.reandroid.arsc.coder.xml.AaptXmlStringDecoder
@@ -38,6 +39,7 @@ import java.io.File
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 import java.util.logging.Logger
+import kotlin.time.measureTimedValue
 
 internal class ArsclibResourceCoder(
     internal val workingDir: File,
@@ -296,11 +298,90 @@ internal class ArsclibResourceCoder(
         val encoder = ApkModuleXmlEncoder()
         encoder.apkModule.use { loadedModule ->
             loadedModule.setPreferredFramework(lazyPackageInfo.value.frameworkVersion)
-            encoder.scanDirectory(workingDir)
-            loadedModule.writeApk(outputApk)
+            val scanDuration = measureTimedValue {
+                encoder.scanDirectory(workingDir)
+            }.duration
+
+            ApkModule.loadApkFile(apkFile).use { originalModule ->
+                val changedEntries = changedArchiveEntries(originalPackageName != newPackageName)
+                val reusedEntries = reuseUnchangedArchiveEntries(originalModule, loadedModule, changedEntries)
+                val rebuiltEntries = loadedModule.zipEntryMap.listInputSources().size - reusedEntries
+
+                logger.info(
+                    "Resource APK inputs: reusing $reusedEntries unchanged archive entries, " +
+                            "rebuilding $rebuiltEntries entries",
+                )
+
+                val writeDuration = measureTimedValue {
+                    loadedModule.writeApk(outputApk)
+                }.duration
+
+                logger.info("Resource APK timings: scan=$scanDuration, write=$writeDuration")
+            }
         }
 
         return outputApk
+    }
+
+    /**
+     * Returns original APK entry names which must be rebuilt from the decoded resource tree.
+     */
+    internal fun changedArchiveEntries(packageRenamed: Boolean): Set<String> = buildSet {
+        add("AndroidManifest.xml")
+        add("resources.arsc")
+
+        modifiedResResources.forEach { file ->
+            packageDirectories.values.firstNotNullOfOrNull { packageDirectory ->
+                file.archivePathRelativeToOrNull(packageDirectory)
+            }?.let(::add)
+        }
+
+        modifiedBinaryResources.forEach { file ->
+            file.archivePathRelativeToOrNull(otherResourcesRootDirectory)?.let(::add)
+        }
+
+        // PackageRenamingProcessor may rewrite resource XMLs which patches did not directly touch.
+        // Rebuild all compiled resources when that processor ran, while still reusing unchanged APK-root files.
+        if (packageRenamed) {
+            packageDirectories.values.forEach { packageDirectory ->
+                packageDirectory.resolve("res").walkTopDown().filter { it.isFile }.forEach { file ->
+                    file.archivePathRelativeToOrNull(packageDirectory)?.let(::add)
+                }
+            }
+        }
+    }
+
+    /**
+     * Replaces unchanged filesystem-backed encoder inputs with archive-backed inputs from [originalModule].
+     * ARSCLib can raw-copy those entries in their existing compressed form instead of reopening and recompressing
+     * every extracted file.
+     */
+    internal fun reuseUnchangedArchiveEntries(
+        originalModule: ApkModule,
+        encodedModule: ApkModule,
+        changedEntries: Set<String>,
+    ): Int {
+        val encodedEntries = encodedModule.zipEntryMap
+        var reusedEntries = 0
+
+        originalModule.zipEntryMap.listInputSources().forEach { originalSource: InputSource ->
+            val entryName = originalSource.alias
+            if (entryName !in changedEntries && encodedEntries.contains(entryName)) {
+                encodedEntries.add(originalSource)
+                reusedEntries++
+            }
+        }
+
+        return reusedEntries
+    }
+
+    private fun File.archivePathRelativeToOrNull(baseDirectory: File): String? {
+        val filePath = absoluteFile.toPath().normalize()
+        val basePath = baseDirectory.absoluteFile.toPath().normalize()
+        if (!filePath.startsWith(basePath)) return null
+
+        val alias = basePath.relativize(filePath).toString().replace(File.separatorChar, '/')
+        return pathMap.getOriginalName(alias) ?: alias
     }
 
     override fun getOtherResourceFiles(outputDir: File, resourceMode: ResourceMode): File? {

--- a/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
@@ -5,7 +5,6 @@
 
 package app.morphe.patcher.resource.coder
 
-import kotlin.time.measureTimedValue
 import com.reandroid.archive.InputSource
 import app.morphe.patcher.PackageMetadata
 import app.morphe.patcher.Patcher
@@ -44,7 +43,10 @@ import org.w3c.dom.Element
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.attribute.FileTime
 import java.util.logging.Logger
+import kotlin.time.measureTime
 
 /**
  * A mobile country code and a mobile network code are three digits, so a device never reports one
@@ -95,10 +97,16 @@ internal class ArsclibResourceCoder(
     internal val deletedFiles = mutableSetOf<String>()
 
     /**
-     * Snapshot of file metadata (modification time and size) captured after decoding resources.
-     * Used to detect which files were added or modified between decoding and encoding.
+     * Snapshot of file metadata and identity captured after decoding resources.
+     * High-resolution timestamps and file keys catch same-size rewrites and replacement files without rereading every
+     * decoded resource payload.
      */
-    internal data class FileSnapshot(val lastModified: Long, val size: Long)
+    internal class FileSnapshot(
+        val creationTime: FileTime,
+        val lastModified: FileTime,
+        val size: Long,
+        val fileKey: Any?,
+    )
     internal var fileSnapshotCache: MutableMap<String, FileSnapshot> = mutableMapOf()
 
     /**
@@ -153,7 +161,7 @@ internal class ArsclibResourceCoder(
         val snapshot = mutableMapOf<String, FileSnapshot>()
         sequenceOf(workingDir.resolve("resources"), otherResourcesRootDirectory).forEach { dir ->
             dir.walkTopDown().filter { it.isFile }.forEach { file ->
-                snapshot[pathKey(file)] = FileSnapshot(file.lastModified(), file.length())
+                snapshot[pathKey(file)] = file.snapshot()
             }
         }
         return snapshot
@@ -174,7 +182,7 @@ internal class ArsclibResourceCoder(
                 if (excludedPaths.contains(relativePath)) return@forEach
 
                 val cached = fileSnapshotCache[pathKey(file)]
-                if (cached == null || file.lastModified() != cached.lastModified || file.length() != cached.size) {
+                if (file.differsFrom(cached)) {
                     modifiedResResources.add(file)
                 }
             }
@@ -191,7 +199,7 @@ internal class ArsclibResourceCoder(
                 return@forEach
             }
             val cached = fileSnapshotCache[pathKey(file)]
-            if (cached == null || file.lastModified() != cached.lastModified || file.length() != cached.size) {
+            if (file.differsFrom(cached)) {
                 modifiedBinaryResources.add(file)
             }
         }
@@ -494,10 +502,10 @@ internal class ArsclibResourceCoder(
             val encoder = ApkModuleXmlEncoder()
             encoder.apkModule.use { loadedModule ->
                 loadedModule.setPreferredFramework(lazyPackageInfo.value.frameworkVersion)
-                val scanDuration = measureTimedValue {
+                val scanDuration = measureTime {
                     encoder.scanDirectory(workingDir)
                     loadedModule.encodePatchedConfigurations(patchedConfigurations)
-                }.duration
+                }
 
                 ApkModule.loadApkFile(apkFile).use { originalModule ->
                     val changedEntries = changedArchiveEntries(originalPackageName != newPackageName)
@@ -509,9 +517,9 @@ internal class ArsclibResourceCoder(
                                 "rebuilding $rebuiltEntries entries",
                     )
 
-                    val writeDuration = measureTimedValue {
+                    val writeDuration = measureTime {
                         loadedModule.writeApk(outputApk)
-                    }.duration
+                    }
 
                     logger.info("Resource APK timings: scan=$scanDuration, write=$writeDuration")
                 }
@@ -727,6 +735,25 @@ internal class ArsclibResourceCoder(
     private fun qualifiersOf(resourceDirectory: File): String {
         val separator = resourceDirectory.name.indexOf('-')
         return if (separator > 0) resourceDirectory.name.substring(separator) else ""
+    }
+
+    private fun File.snapshot(): FileSnapshot {
+        val attributes = Files.readAttributes(toPath(), BasicFileAttributes::class.java)
+        return FileSnapshot(
+            attributes.creationTime(),
+            attributes.lastModifiedTime(),
+            attributes.size(),
+            attributes.fileKey(),
+        )
+    }
+
+    private fun File.differsFrom(snapshot: FileSnapshot?): Boolean {
+        if (snapshot == null) return true
+        val attributes = Files.readAttributes(toPath(), BasicFileAttributes::class.java)
+        return attributes.creationTime() != snapshot.creationTime ||
+                attributes.lastModifiedTime() != snapshot.lastModified ||
+                attributes.size() != snapshot.size ||
+                attributes.fileKey() != snapshot.fileKey
     }
 
     override fun getOtherResourceFiles(outputDir: File, resourceMode: ResourceMode): File? {
@@ -957,7 +984,7 @@ internal class ArsclibResourceCoder(
         // filesystem timestamp tick, and same-length edits would otherwise read as unchanged.
         lazilyExtractedRootFiles[pathKey(destination)] =
             ExtractedRootFile(destination.length(), destination.readBytes().contentHashCode())
-        fileSnapshotCache[pathKey(destination)] = FileSnapshot(destination.lastModified(), destination.length())
+        fileSnapshotCache[pathKey(destination)] = destination.snapshot()
         logger.fine("Extracted root entry on demand: $apkPath")
     }
 

--- a/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
@@ -5,6 +5,8 @@
 
 package app.morphe.patcher.resource.coder
 
+import kotlin.time.measureTimedValue
+import com.reandroid.archive.InputSource
 import app.morphe.patcher.PackageMetadata
 import app.morphe.patcher.Patcher
 import app.morphe.patcher.PatcherResult
@@ -492,9 +494,27 @@ internal class ArsclibResourceCoder(
             val encoder = ApkModuleXmlEncoder()
             encoder.apkModule.use { loadedModule ->
                 loadedModule.setPreferredFramework(lazyPackageInfo.value.frameworkVersion)
-                encoder.scanDirectory(workingDir)
-                loadedModule.encodePatchedConfigurations(patchedConfigurations)
-                loadedModule.writeApk(outputApk)
+                val scanDuration = measureTimedValue {
+                    encoder.scanDirectory(workingDir)
+                    loadedModule.encodePatchedConfigurations(patchedConfigurations)
+                }.duration
+
+                ApkModule.loadApkFile(apkFile).use { originalModule ->
+                    val changedEntries = changedArchiveEntries(originalPackageName != newPackageName)
+                    val reusedEntries = reuseUnchangedArchiveEntries(originalModule, loadedModule, changedEntries)
+                    val rebuiltEntries = loadedModule.zipEntryMap.listInputSources().size - reusedEntries
+
+                    logger.info(
+                        "Resource APK inputs: reusing $reusedEntries unchanged archive entries, " +
+                                "rebuilding $rebuiltEntries entries",
+                    )
+
+                    val writeDuration = measureTimedValue {
+                        loadedModule.writeApk(outputApk)
+                    }.duration
+
+                    logger.info("Resource APK timings: scan=$scanDuration, write=$writeDuration")
+                }
             }
         } finally {
             patchedConfigurations.forEach { it.restore() }
@@ -502,6 +522,67 @@ internal class ArsclibResourceCoder(
         }
 
         return outputApk
+    }
+
+    /**
+     * Returns original APK entry names which must be rebuilt from the decoded resource tree.
+     */
+    internal fun changedArchiveEntries(packageRenamed: Boolean): Set<String> = buildSet {
+        add("AndroidManifest.xml")
+        add("resources.arsc")
+
+        modifiedResResources.forEach { file ->
+            packageDirectories.values.firstNotNullOfOrNull { packageDirectory ->
+                file.archivePathRelativeToOrNull(packageDirectory)
+            }?.let(::add)
+        }
+
+        modifiedBinaryResources.forEach { file ->
+            file.archivePathRelativeToOrNull(otherResourcesRootDirectory)?.let(::add)
+        }
+
+        // PackageRenamingProcessor may rewrite resource XMLs which patches did not directly touch.
+        // Rebuild all compiled resources when that processor ran, while still reusing unchanged APK-root files.
+        if (packageRenamed) {
+            packageDirectories.values.forEach { packageDirectory ->
+                packageDirectory.resolve("res").walkTopDown().filter { it.isFile }.forEach { file ->
+                    file.archivePathRelativeToOrNull(packageDirectory)?.let(::add)
+                }
+            }
+        }
+    }
+
+    /**
+     * Replaces unchanged filesystem-backed encoder inputs with archive-backed inputs from [originalModule].
+     * ARSCLib can raw-copy those entries in their existing compressed form instead of reopening and recompressing
+     * every extracted file.
+     */
+    internal fun reuseUnchangedArchiveEntries(
+        originalModule: ApkModule,
+        encodedModule: ApkModule,
+        changedEntries: Set<String>,
+    ): Int {
+        val encodedEntries = encodedModule.zipEntryMap
+        var reusedEntries = 0
+
+        originalModule.zipEntryMap.listInputSources().forEach { originalSource: InputSource ->
+            val entryName = originalSource.alias
+            if (entryName !in changedEntries && encodedEntries.contains(entryName)) {
+                encodedEntries.add(originalSource)
+                reusedEntries++
+            }
+        }
+
+        return reusedEntries
+    }
+
+    private fun File.archivePathRelativeToOrNull(baseDirectory: File): String? {
+        val filePath = absoluteFile.toPath().normalize()
+        val basePath = baseDirectory.absoluteFile.toPath().normalize()
+        if (!filePath.startsWith(basePath)) return null
+
+        val alias = basePath.relativize(filePath).toString().replace(File.separatorChar, '/')
+        return pathMap.getOriginalName(alias) ?: alias
     }
 
     /**

--- a/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
@@ -5,7 +5,6 @@
 
 package app.morphe.patcher.resource.coder
 
-import com.reandroid.archive.InputSource
 import app.morphe.patcher.PackageMetadata
 import app.morphe.patcher.Patcher
 import app.morphe.patcher.PatcherResult
@@ -30,6 +29,7 @@ import com.reandroid.apk.ApkModule
 import com.reandroid.apk.ApkModuleRawDecoder
 import com.reandroid.apk.ApkModuleXmlDecoder
 import com.reandroid.apk.ApkModuleXmlEncoder
+import com.reandroid.archive.InputSource
 import com.reandroid.archive.block.ApkSignatureBlock
 import com.reandroid.arsc.chunk.PackageBlock
 import com.reandroid.arsc.coder.CoderSetting
@@ -111,10 +111,9 @@ internal class ArsclibResourceCoder(
 
     /**
      * Native libraries are left in the input APK instead of being staged to disk:
-     * [ApkUtils.applyTo] rebuilds the output from a copy of that same APK, so every unchanged
-     * entry is already present and correct in the target. They are extracted only when a patch
-     * asks for one by path, through [getFile]; every other root entry is staged during decode,
-     * because a patch that discovers files by walking the directory can only see what is there.
+     * [reuseUnchangedArchiveEntries] carries them into the compiled resource APK without extraction.
+     * They are extracted through [getFile] only when requested. Other root entries are staged
+     * during decode so patches can find them by walking the directory.
      */
     private val lazilyExtractedRootFiles = mutableMapOf<String, ExtractedRootFile>()
 
@@ -533,11 +532,14 @@ internal class ArsclibResourceCoder(
     }
 
     /**
-     * Returns original APK entry names which must be rebuilt from the decoded resource tree.
+     * Returns original APK entry names which cannot be reused.
      */
     internal fun changedArchiveEntries(packageRenamed: Boolean): Set<String> = buildSet {
         add("AndroidManifest.xml")
         add("resources.arsc")
+        addAll(deletedFiles)
+        addAll(strippedLibraries)
+        addAll(relocatedRootFiles.values)
 
         modifiedResResources.forEach { file ->
             packageDirectories.values.firstNotNullOfOrNull { packageDirectory ->
@@ -561,9 +563,8 @@ internal class ArsclibResourceCoder(
     }
 
     /**
-     * Replaces unchanged filesystem-backed encoder inputs with archive-backed inputs from [originalModule].
-     * ARSCLib can raw-copy those entries in their existing compressed form instead of reopening and recompressing
-     * every extracted file.
+     * Reuses unchanged archive entries, including root files omitted by the encoder.
+     * ARSCLib copies their compressed data without recompressing it.
      */
     internal fun reuseUnchangedArchiveEntries(
         originalModule: ApkModule,
@@ -575,7 +576,10 @@ internal class ArsclibResourceCoder(
 
         originalModule.zipEntryMap.listInputSources().forEach { originalSource: InputSource ->
             val entryName = originalSource.alias
-            if (entryName !in changedEntries && encodedEntries.contains(entryName)) {
+            val alias = aliasOf(entryName)
+            val rootEntry = !stagesRootEntry(alias) ||
+                    pathKey(otherResourcesRootDirectory.resolve(alias)) in fileSnapshotCache
+            if (entryName !in changedEntries && (encodedEntries.contains(entryName) || rootEntry)) {
                 encodedEntries.add(originalSource)
                 reusedEntries++
             }

--- a/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
@@ -98,8 +98,8 @@ internal class ArsclibResourceCoder(
 
     /**
      * Snapshot of file metadata and identity captured after decoding resources.
-     * High-resolution timestamps and file keys catch same-size rewrites and replacement files without rereading every
-     * decoded resource payload.
+     * High-resolution timestamps and file keys improve same-size change detection when the filesystem exposes
+     * distinguishable metadata, without rereading every decoded resource payload.
      */
     internal class FileSnapshot(
         val creationTime: FileTime,

--- a/src/test/kotlin/app/morphe/patcher/apk/ApkUtilsTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/apk/ApkUtilsTest.kt
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patcher
+ */
+
+package app.morphe.patcher.apk
+
+import app.morphe.patcher.PatcherResult
+import app.morphe.patcher.apk.ApkUtils.applyTo
+import org.junit.jupiter.api.io.TempDir
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipFile
+import java.util.zip.ZipOutputStream
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+internal class ApkUtilsTest {
+    @TempDir
+    lateinit var temporaryDirectory: File
+
+    @Test
+    fun `compiled resource APK is used directly as the output base`() {
+        val targetApk = temporaryDirectory.resolve("target.apk").also { apk ->
+            writeZip(
+                apk,
+                mapOf(
+                    "assets/original-only.txt" to "original".toByteArray(),
+                    "res/raw/old.txt" to "old".toByteArray(),
+                    "classes.dex" to "original dex".toByteArray(),
+                ),
+            )
+        }
+        val resourcesApk = temporaryDirectory.resolve("resources.apk").also { apk ->
+            writeZip(
+                apk,
+                mapOf(
+                    "assets/resource-base-only.txt" to "resource base".toByteArray(),
+                    "assets/delete-me.txt" to "delete me".toByteArray(),
+                    "res/raw/new.txt" to "new".toByteArray(),
+                    "classes.dex" to "stale dex".toByteArray(),
+                    "classes99.dex" to "stale dex 99".toByteArray(),
+                ),
+            )
+        }
+        val otherResources = temporaryDirectory.resolve("other-resources").also { directory ->
+            directory.resolve("assets/raw-added.txt").apply {
+                parentFile.mkdirs()
+                writeText("raw resource")
+            }
+        }
+        val primaryDex = CloseTrackingInputStream("patched dex".toByteArray())
+        val secondaryDex = CloseTrackingInputStream("patched dex 2".toByteArray())
+        val result = PatcherResult(
+            linkedSetOf(
+                PatcherResult.PatchedDexFile("classes.dex", primaryDex),
+                PatcherResult.PatchedDexFile("classes2.dex", secondaryDex),
+            ),
+            PatcherResult.PatchedResources(
+                resourcesApk,
+                otherResources,
+                setOf("assets/raw-added.txt"),
+                setOf("assets/delete-me.txt"),
+            ),
+        )
+
+        result.applyTo(targetApk)
+
+        val entries = readZip(targetApk)
+        assertFalse("assets/original-only.txt" in entries)
+        assertFalse("res/raw/old.txt" in entries)
+        assertFalse("assets/delete-me.txt" in entries)
+        assertFalse("classes99.dex" in entries)
+        assertContentEquals("resource base".toByteArray(), entries["assets/resource-base-only.txt"])
+        assertContentEquals("new".toByteArray(), entries["res/raw/new.txt"])
+        assertContentEquals("raw resource".toByteArray(), entries["assets/raw-added.txt"])
+        assertContentEquals("patched dex".toByteArray(), entries["classes.dex"])
+        assertContentEquals("patched dex 2".toByteArray(), entries["classes2.dex"])
+        assertTrue(primaryDex.closed)
+        assertTrue(secondaryDex.closed)
+    }
+
+    @Test
+    fun `original APK remains the output base without a compiled resource APK`() {
+        val targetApk = temporaryDirectory.resolve("target.apk").also { apk ->
+            writeZip(
+                apk,
+                mapOf(
+                    "assets/original-only.txt" to "original".toByteArray(),
+                    "assets/delete-me.txt" to "delete me".toByteArray(),
+                    "classes.dex" to "original dex".toByteArray(),
+                    "classes2.dex" to "untouched dex".toByteArray(),
+                ),
+            )
+        }
+        val otherResources = temporaryDirectory.resolve("other-resources").also { directory ->
+            directory.resolve("assets/raw-added.txt").apply {
+                parentFile.mkdirs()
+                writeText("raw resource")
+            }
+        }
+        val primaryDex = CloseTrackingInputStream("patched dex".toByteArray())
+        val result = PatcherResult(
+            setOf(PatcherResult.PatchedDexFile("classes.dex", primaryDex)),
+            PatcherResult.PatchedResources(
+                null,
+                otherResources,
+                emptySet(),
+                setOf("assets/delete-me.txt"),
+            ),
+        )
+
+        result.applyTo(targetApk)
+
+        val entries = readZip(targetApk)
+        assertContentEquals("original".toByteArray(), entries["assets/original-only.txt"])
+        assertFalse("assets/delete-me.txt" in entries)
+        assertContentEquals("raw resource".toByteArray(), entries["assets/raw-added.txt"])
+        assertContentEquals("patched dex".toByteArray(), entries["classes.dex"])
+        assertContentEquals("untouched dex".toByteArray(), entries["classes2.dex"])
+        assertTrue(primaryDex.closed)
+    }
+
+    private fun writeZip(file: File, entries: Map<String, ByteArray>) {
+        ZipOutputStream(file.outputStream()).use { output ->
+            entries.forEach { (name, contents) ->
+                output.putNextEntry(ZipEntry(name))
+                output.write(contents)
+                output.closeEntry()
+            }
+        }
+    }
+
+    private fun readZip(file: File): Map<String, ByteArray> =
+        ZipFile(file).use { zip ->
+            zip.entries().asSequence().associate { entry ->
+                entry.name to zip.getInputStream(entry).use { it.readBytes() }
+            }
+        }
+
+    private class CloseTrackingInputStream(contents: ByteArray) : ByteArrayInputStream(contents) {
+        var closed = false
+            private set
+
+        override fun close() {
+            closed = true
+            super.close()
+        }
+    }
+}

--- a/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
@@ -13,12 +13,17 @@ import com.reandroid.apk.ApkModule
 import com.reandroid.archive.FileInputSource
 import com.reandroid.archive.io.ArchiveFileEntrySource
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import java.io.ByteArrayInputStream
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.nio.file.attribute.FileTime
+import java.util.concurrent.TimeUnit
 import java.util.zip.ZipFile
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -75,7 +80,7 @@ internal class ArsclibResourceCoderTest {
         val snapshot = coder.buildFileSnapshot()
         val entry = snapshot[file]!!
 
-        assertEquals(file.lastModified(), entry.lastModified)
+        assertEquals(Files.getLastModifiedTime(file.toPath()), entry.lastModified)
         assertEquals(file.length(), entry.size)
     }
 
@@ -145,10 +150,7 @@ internal class ArsclibResourceCoderTest {
 
         // Build a snapshot with the original size.
         val originalLastModified = file.lastModified()
-        val originalSize = file.length()
-        val snapshotEntry = ArsclibResourceCoder.FileSnapshot(originalLastModified, originalSize)
-
-        coder.fileSnapshotCache = mapOf(file to snapshotEntry)
+        coder.fileSnapshotCache = coder.buildFileSnapshot()
 
         // Change the content (and thus the size) but preserve the timestamp.
         file.writeText("this is a much longer string to change the file size")
@@ -176,6 +178,60 @@ internal class ArsclibResourceCoderTest {
 
         assertTrue(coder.modifiedResResources.isEmpty(), "No files should be in modifiedResResources")
         assertTrue(coder.modifiedBinaryResources.isEmpty(), "No files should be in modifiedBinaryResources")
+    }
+
+    @Test
+    fun `detectFileChanges identifies same-size replacement resource with preserved timestamp`() {
+        val pkgDir = setupPackageDir()
+        val file = pkgDir.resolve("res/values/strings.xml").apply {
+            parentFile.mkdirs()
+            writeText("before")
+        }
+        val originalLastModified = Files.getLastModifiedTime(file.toPath())
+        coder.fileSnapshotCache = coder.buildFileSnapshot()
+
+        Thread.sleep(10)
+        val replacement = file.resolveSibling("replacement.xml").apply { writeText("after!") }
+        Files.setLastModifiedTime(replacement.toPath(), originalLastModified)
+        Files.move(replacement.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING)
+
+        coder.detectFileChanges()
+
+        assertTrue(
+            coder.modifiedResResources.contains(file),
+            "A replacement file must not be hidden by identical size and timestamp metadata",
+        )
+    }
+
+    @Test
+    fun `detectFileChanges identifies high-resolution timestamp changes`() {
+        val file = coder.otherResourcesRootDirectory.resolve("assets/data.bin").apply {
+            parentFile.mkdirs()
+            writeBytes(byteArrayOf(1, 2, 3, 4))
+        }
+        val originalLastModified = FileTime.fromMillis(System.currentTimeMillis() - 1_000)
+        Files.setLastModifiedTime(file.toPath(), originalLastModified)
+        coder.fileSnapshotCache = coder.buildFileSnapshot()
+
+        file.writeBytes(byteArrayOf(4, 3, 2, 1))
+        val subMillisecondChange = FileTime.from(
+            originalLastModified.to(TimeUnit.NANOSECONDS) + 100_000,
+            TimeUnit.NANOSECONDS,
+        )
+        Files.setLastModifiedTime(
+            file.toPath(),
+            subMillisecondChange,
+        )
+        val storedLastModified = Files.getLastModifiedTime(file.toPath())
+        assumeTrue(storedLastModified != originalLastModified, "Filesystem does not retain sub-millisecond timestamps")
+        assumeTrue(storedLastModified.toMillis() == originalLastModified.toMillis())
+
+        coder.detectFileChanges()
+
+        assertTrue(
+            coder.modifiedBinaryResources.contains(file),
+            "Same-size changes must be detected from the filesystem timestamp",
+        )
     }
 
     // ==================== resource APK input reuse tests ====================

--- a/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
@@ -22,6 +22,7 @@ import java.io.ByteArrayInputStream
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
+import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.attribute.FileTime
 import java.util.concurrent.TimeUnit
 import java.util.zip.ZipFile
@@ -181,19 +182,25 @@ internal class ArsclibResourceCoderTest {
     }
 
     @Test
-    fun `detectFileChanges identifies same-size replacement resource with preserved timestamp`() {
+    fun `detectFileChanges identifies replacement when filesystem exposes changed metadata`() {
         val pkgDir = setupPackageDir()
         val file = pkgDir.resolve("res/values/strings.xml").apply {
             parentFile.mkdirs()
             writeText("before")
         }
-        val originalLastModified = Files.getLastModifiedTime(file.toPath())
+        val originalAttributes = Files.readAttributes(file.toPath(), BasicFileAttributes::class.java)
         coder.fileSnapshotCache = coder.buildFileSnapshot()
 
         Thread.sleep(10)
         val replacement = file.resolveSibling("replacement.xml").apply { writeText("after!") }
-        Files.setLastModifiedTime(replacement.toPath(), originalLastModified)
+        Files.setLastModifiedTime(replacement.toPath(), originalAttributes.lastModifiedTime())
         Files.move(replacement.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING)
+        val replacementAttributes = Files.readAttributes(file.toPath(), BasicFileAttributes::class.java)
+        assumeTrue(
+            replacementAttributes.creationTime() != originalAttributes.creationTime() ||
+                    replacementAttributes.fileKey() != originalAttributes.fileKey(),
+            "Filesystem does not expose distinguishable metadata for this replacement",
+        )
 
         coder.detectFileChanges()
 

--- a/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
@@ -9,6 +9,9 @@ import app.morphe.patcher.resource.CpuArchitecture
 import app.morphe.patcher.resource.PathMap
 import app.morphe.patcher.resource.ResourceMode
 import com.android.tools.build.apkzlib.zip.ZFile
+import com.reandroid.apk.ApkModule
+import com.reandroid.archive.FileInputSource
+import com.reandroid.archive.io.ArchiveFileEntrySource
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -16,8 +19,10 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import java.io.ByteArrayInputStream
 import java.io.File
+import java.util.zip.ZipFile
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 internal class ArsclibResourceCoderTest {
@@ -171,6 +176,104 @@ internal class ArsclibResourceCoderTest {
 
         assertTrue(coder.modifiedResResources.isEmpty(), "No files should be in modifiedResResources")
         assertTrue(coder.modifiedBinaryResources.isEmpty(), "No files should be in modifiedBinaryResources")
+    }
+
+    // ==================== resource APK input reuse tests ====================
+
+    @Test
+    fun `changedArchiveEntries maps decoded aliases back to original APK paths`() {
+        val packageDir = setupPackageDir()
+        val modifiedResource = packageDir.resolve("res/layout/readable.xml").apply {
+            parentFile.mkdirs()
+            writeText("<LinearLayout/>")
+        }
+        val modifiedBinary = coder.otherResourcesRootDirectory.resolve("assets/readable.bin").apply {
+            parentFile.mkdirs()
+            writeBytes(byteArrayOf(1, 2, 3))
+        }
+        coder.pathMap = PathMap(
+            """[
+                {"name":"res/a.xml","alias":"res/layout/readable.xml"},
+                {"name":"assets/b.bin","alias":"assets/readable.bin"}
+            ]""".trimIndent(),
+        )
+        coder.modifiedResResources += modifiedResource
+        coder.modifiedBinaryResources += modifiedBinary
+
+        val changedEntries = coder.changedArchiveEntries(packageRenamed = false)
+
+        assertEquals(
+            setOf("AndroidManifest.xml", "resources.arsc", "res/a.xml", "assets/b.bin"),
+            changedEntries,
+        )
+    }
+
+    @Test
+    fun `changedArchiveEntries rebuilds all compiled resources after package rename`() {
+        val packageDir = setupPackageDir()
+        packageDir.resolve("res/layout/unchanged.xml").apply {
+            parentFile.mkdirs()
+            writeText("<LinearLayout/>")
+        }
+        packageDir.resolve("res/drawable/unchanged.png").apply {
+            parentFile.mkdirs()
+            writeBytes(byteArrayOf(1, 2, 3))
+        }
+
+        val changedEntries = coder.changedArchiveEntries(packageRenamed = true)
+
+        assertTrue("res/layout/unchanged.xml" in changedEntries)
+        assertTrue("res/drawable/unchanged.png" in changedEntries)
+    }
+
+    @Test
+    fun `reuseUnchangedArchiveEntries preserves changed and new encoder inputs`(@TempDir tempDir: File) {
+        val originalApk = tempDir.resolve("original.apk")
+        ZFile.openReadWrite(originalApk).use { zip ->
+            zip.add("unchanged.bin", ByteArrayInputStream("original unchanged".toByteArray()))
+            zip.add("changed.bin", ByteArrayInputStream("original changed".toByteArray()))
+            zip.add("deleted.bin", ByteArrayInputStream("deleted".toByteArray()))
+        }
+
+        val encodedModule = ApkModule()
+        val unchangedFile = tempDir.resolve("unchanged.bin").apply { writeText("filesystem unchanged") }
+        val changedFile = tempDir.resolve("changed.bin").apply { writeText("patched changed") }
+        val newFile = tempDir.resolve("new.bin").apply { writeText("new") }
+        encodedModule.add(FileInputSource(unchangedFile, "unchanged.bin"))
+        encodedModule.add(FileInputSource(changedFile, "changed.bin"))
+        encodedModule.add(FileInputSource(newFile, "new.bin"))
+
+        val testCoder = ArsclibResourceCoder(tempDir.resolve("working").apply { mkdirs() }, originalApk)
+        ApkModule.loadApkFile(originalApk).use { originalModule ->
+            encodedModule.use { module ->
+                val reused = testCoder.reuseUnchangedArchiveEntries(
+                    originalModule,
+                    module,
+                    setOf("changed.bin"),
+                )
+
+                assertEquals(1, reused)
+                assertIs<ArchiveFileEntrySource>(module.zipEntryMap.getInputSource("unchanged.bin"))
+                assertIs<FileInputSource>(module.zipEntryMap.getInputSource("changed.bin"))
+                assertIs<FileInputSource>(module.zipEntryMap.getInputSource("new.bin"))
+                assertFalse(module.zipEntryMap.contains("deleted.bin"))
+
+                val outputApk = tempDir.resolve("output.apk")
+                module.writeApk(outputApk)
+                ZipFile(outputApk).use { zip ->
+                    assertEquals(
+                        "original unchanged",
+                        zip.getInputStream(zip.getEntry("unchanged.bin")).bufferedReader().readText(),
+                    )
+                    assertEquals(
+                        "patched changed",
+                        zip.getInputStream(zip.getEntry("changed.bin")).bufferedReader().readText(),
+                    )
+                    assertEquals("new", zip.getInputStream(zip.getEntry("new.bin")).bufferedReader().readText())
+                    assertEquals(null, zip.getEntry("deleted.bin"))
+                }
+            }
+        }
     }
 
     @Test

--- a/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
@@ -399,6 +399,52 @@ internal class ArsclibResourceCoderTest {
     }
 
     @Test
+    fun `reuseUnchangedArchiveEntries retains omitted root entries but not deleted files or dex`(
+        @TempDir tempDir: File,
+    ) {
+        val originalApk = tempDir.resolve("original.apk")
+        val entries = listOf(
+            "lib/arm64-v8a/keep.so", "lib/arm64-v8a/deleted.so", "lib/x86/stripped.so",
+            "assets/keep.txt", "assets/deleted.txt", "classes.dex", "res/raw/deleted.txt",
+        )
+        ZFile.openReadWrite(originalApk).use { zip ->
+            entries.forEach { zip.add(it, ByteArrayInputStream(it.toByteArray())) }
+        }
+        val testCoder = ArsclibResourceCoder(
+            tempDir.resolve("working").apply { mkdirs() }, originalApk, setOf(CpuArchitecture.ARM64_V8A),
+        )
+        val asset = testCoder.otherResourcesRootDirectory.resolve("assets/keep.txt").apply {
+            parentFile.mkdirs()
+            writeText("assets/keep.txt")
+        }
+        testCoder.fileSnapshotCache = testCoder.buildFileSnapshot()
+        asset.delete()
+        testCoder.deletedFiles += listOf("lib/arm64-v8a/deleted.so", "assets/deleted.txt")
+        testCoder.stripNativeLibraries()
+
+        ApkModule.loadApkFile(originalApk).use { original ->
+            ApkModule().use { encoded ->
+                assertEquals(
+                    2,
+                    testCoder.reuseUnchangedArchiveEntries(original, encoded, testCoder.changedArchiveEntries(false)),
+                )
+                val output = tempDir.resolve("output.apk")
+                encoded.writeApk(output)
+                ZipFile(output).use { zip ->
+                    assertEquals(
+                        setOf("lib/arm64-v8a/keep.so", "assets/keep.txt"),
+                        zip.entries().asSequence().map { it.name }.toSet(),
+                    )
+                    assertEquals(
+                        "assets/keep.txt",
+                        zip.getInputStream(zip.getEntry("assets/keep.txt")).bufferedReader().readText(),
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
     fun `detectFileChanges excludes public xml from tracking`() {
         val pkgDir = setupPackageDir()
         val resDir = pkgDir.resolve("res")

--- a/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
@@ -22,6 +22,7 @@ import java.io.ByteArrayInputStream
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
+import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.attribute.FileTime
 import java.util.concurrent.TimeUnit
 import java.util.zip.ZipFile
@@ -240,19 +241,25 @@ internal class ArsclibResourceCoderTest {
     }
 
     @Test
-    fun `detectFileChanges identifies same-size replacement resource with preserved timestamp`() {
+    fun `detectFileChanges identifies replacement when filesystem exposes changed metadata`() {
         val pkgDir = setupPackageDir()
         val file = pkgDir.resolve("res/values/strings.xml").apply {
             parentFile.mkdirs()
             writeText("before")
         }
-        val originalLastModified = Files.getLastModifiedTime(file.toPath())
+        val originalAttributes = Files.readAttributes(file.toPath(), BasicFileAttributes::class.java)
         coder.fileSnapshotCache = coder.buildFileSnapshot()
 
         Thread.sleep(10)
         val replacement = file.resolveSibling("replacement.xml").apply { writeText("after!") }
-        Files.setLastModifiedTime(replacement.toPath(), originalLastModified)
+        Files.setLastModifiedTime(replacement.toPath(), originalAttributes.lastModifiedTime())
         Files.move(replacement.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING)
+        val replacementAttributes = Files.readAttributes(file.toPath(), BasicFileAttributes::class.java)
+        assumeTrue(
+            replacementAttributes.creationTime() != originalAttributes.creationTime() ||
+                    replacementAttributes.fileKey() != originalAttributes.fileKey(),
+            "Filesystem does not expose distinguishable metadata for this replacement",
+        )
 
         coder.detectFileChanges()
 

--- a/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
@@ -9,6 +9,9 @@ import app.morphe.patcher.resource.CpuArchitecture
 import app.morphe.patcher.resource.PathMap
 import app.morphe.patcher.resource.ResourceMode
 import com.android.tools.build.apkzlib.zip.ZFile
+import com.reandroid.apk.ApkModule
+import com.reandroid.archive.FileInputSource
+import com.reandroid.archive.io.ArchiveFileEntrySource
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -16,8 +19,10 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import java.io.ByteArrayInputStream
 import java.io.File
+import java.util.zip.ZipFile
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 internal class ArsclibResourceCoderTest {
@@ -230,6 +235,104 @@ internal class ArsclibResourceCoderTest {
 
         assertTrue(coder.modifiedResResources.isEmpty(), "No files should be in modifiedResResources")
         assertTrue(coder.modifiedBinaryResources.isEmpty(), "No files should be in modifiedBinaryResources")
+    }
+
+    // ==================== resource APK input reuse tests ====================
+
+    @Test
+    fun `changedArchiveEntries maps decoded aliases back to original APK paths`() {
+        val packageDir = setupPackageDir()
+        val modifiedResource = packageDir.resolve("res/layout/readable.xml").apply {
+            parentFile.mkdirs()
+            writeText("<LinearLayout/>")
+        }
+        val modifiedBinary = coder.otherResourcesRootDirectory.resolve("assets/readable.bin").apply {
+            parentFile.mkdirs()
+            writeBytes(byteArrayOf(1, 2, 3))
+        }
+        coder.pathMap = PathMap(
+            """[
+                {"name":"res/a.xml","alias":"res/layout/readable.xml"},
+                {"name":"assets/b.bin","alias":"assets/readable.bin"}
+            ]""".trimIndent(),
+        )
+        coder.modifiedResResources += modifiedResource
+        coder.modifiedBinaryResources += modifiedBinary
+
+        val changedEntries = coder.changedArchiveEntries(packageRenamed = false)
+
+        assertEquals(
+            setOf("AndroidManifest.xml", "resources.arsc", "res/a.xml", "assets/b.bin"),
+            changedEntries,
+        )
+    }
+
+    @Test
+    fun `changedArchiveEntries rebuilds all compiled resources after package rename`() {
+        val packageDir = setupPackageDir()
+        packageDir.resolve("res/layout/unchanged.xml").apply {
+            parentFile.mkdirs()
+            writeText("<LinearLayout/>")
+        }
+        packageDir.resolve("res/drawable/unchanged.png").apply {
+            parentFile.mkdirs()
+            writeBytes(byteArrayOf(1, 2, 3))
+        }
+
+        val changedEntries = coder.changedArchiveEntries(packageRenamed = true)
+
+        assertTrue("res/layout/unchanged.xml" in changedEntries)
+        assertTrue("res/drawable/unchanged.png" in changedEntries)
+    }
+
+    @Test
+    fun `reuseUnchangedArchiveEntries preserves changed and new encoder inputs`(@TempDir tempDir: File) {
+        val originalApk = tempDir.resolve("original.apk")
+        ZFile.openReadWrite(originalApk).use { zip ->
+            zip.add("unchanged.bin", ByteArrayInputStream("original unchanged".toByteArray()))
+            zip.add("changed.bin", ByteArrayInputStream("original changed".toByteArray()))
+            zip.add("deleted.bin", ByteArrayInputStream("deleted".toByteArray()))
+        }
+
+        val encodedModule = ApkModule()
+        val unchangedFile = tempDir.resolve("unchanged.bin").apply { writeText("filesystem unchanged") }
+        val changedFile = tempDir.resolve("changed.bin").apply { writeText("patched changed") }
+        val newFile = tempDir.resolve("new.bin").apply { writeText("new") }
+        encodedModule.add(FileInputSource(unchangedFile, "unchanged.bin"))
+        encodedModule.add(FileInputSource(changedFile, "changed.bin"))
+        encodedModule.add(FileInputSource(newFile, "new.bin"))
+
+        val testCoder = ArsclibResourceCoder(tempDir.resolve("working").apply { mkdirs() }, originalApk)
+        ApkModule.loadApkFile(originalApk).use { originalModule ->
+            encodedModule.use { module ->
+                val reused = testCoder.reuseUnchangedArchiveEntries(
+                    originalModule,
+                    module,
+                    setOf("changed.bin"),
+                )
+
+                assertEquals(1, reused)
+                assertIs<ArchiveFileEntrySource>(module.zipEntryMap.getInputSource("unchanged.bin"))
+                assertIs<FileInputSource>(module.zipEntryMap.getInputSource("changed.bin"))
+                assertIs<FileInputSource>(module.zipEntryMap.getInputSource("new.bin"))
+                assertFalse(module.zipEntryMap.contains("deleted.bin"))
+
+                val outputApk = tempDir.resolve("output.apk")
+                module.writeApk(outputApk)
+                ZipFile(outputApk).use { zip ->
+                    assertEquals(
+                        "original unchanged",
+                        zip.getInputStream(zip.getEntry("unchanged.bin")).bufferedReader().readText(),
+                    )
+                    assertEquals(
+                        "patched changed",
+                        zip.getInputStream(zip.getEntry("changed.bin")).bufferedReader().readText(),
+                    )
+                    assertEquals("new", zip.getInputStream(zip.getEntry("new.bin")).bufferedReader().readText())
+                    assertEquals(null, zip.getEntry("deleted.bin"))
+                }
+            }
+        }
     }
 
     @Test

--- a/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
@@ -13,12 +13,17 @@ import com.reandroid.apk.ApkModule
 import com.reandroid.archive.FileInputSource
 import com.reandroid.archive.io.ArchiveFileEntrySource
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import java.io.ByteArrayInputStream
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.nio.file.attribute.FileTime
+import java.util.concurrent.TimeUnit
 import java.util.zip.ZipFile
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -134,7 +139,7 @@ internal class ArsclibResourceCoderTest {
         val snapshot = coder.buildFileSnapshot()
         val entry = snapshot[file.snapshotKey]!!
 
-        assertEquals(file.lastModified(), entry.lastModified)
+        assertEquals(Files.getLastModifiedTime(file.toPath()), entry.lastModified)
         assertEquals(file.length(), entry.size)
     }
 
@@ -204,10 +209,7 @@ internal class ArsclibResourceCoderTest {
 
         // Build a snapshot with the original size.
         val originalLastModified = file.lastModified()
-        val originalSize = file.length()
-        val snapshotEntry = ArsclibResourceCoder.FileSnapshot(originalLastModified, originalSize)
-
-        coder.fileSnapshotCache = mutableMapOf(file.snapshotKey to snapshotEntry)
+        coder.fileSnapshotCache = coder.buildFileSnapshot()
 
         // Change the content (and thus the size) but preserve the timestamp.
         file.writeText("this is a much longer string to change the file size")
@@ -235,6 +237,60 @@ internal class ArsclibResourceCoderTest {
 
         assertTrue(coder.modifiedResResources.isEmpty(), "No files should be in modifiedResResources")
         assertTrue(coder.modifiedBinaryResources.isEmpty(), "No files should be in modifiedBinaryResources")
+    }
+
+    @Test
+    fun `detectFileChanges identifies same-size replacement resource with preserved timestamp`() {
+        val pkgDir = setupPackageDir()
+        val file = pkgDir.resolve("res/values/strings.xml").apply {
+            parentFile.mkdirs()
+            writeText("before")
+        }
+        val originalLastModified = Files.getLastModifiedTime(file.toPath())
+        coder.fileSnapshotCache = coder.buildFileSnapshot()
+
+        Thread.sleep(10)
+        val replacement = file.resolveSibling("replacement.xml").apply { writeText("after!") }
+        Files.setLastModifiedTime(replacement.toPath(), originalLastModified)
+        Files.move(replacement.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING)
+
+        coder.detectFileChanges()
+
+        assertTrue(
+            coder.modifiedResResources.contains(file),
+            "A replacement file must not be hidden by identical size and timestamp metadata",
+        )
+    }
+
+    @Test
+    fun `detectFileChanges identifies high-resolution timestamp changes`() {
+        val file = coder.otherResourcesRootDirectory.resolve("assets/data.bin").apply {
+            parentFile.mkdirs()
+            writeBytes(byteArrayOf(1, 2, 3, 4))
+        }
+        val originalLastModified = FileTime.fromMillis(System.currentTimeMillis() - 1_000)
+        Files.setLastModifiedTime(file.toPath(), originalLastModified)
+        coder.fileSnapshotCache = coder.buildFileSnapshot()
+
+        file.writeBytes(byteArrayOf(4, 3, 2, 1))
+        val subMillisecondChange = FileTime.from(
+            originalLastModified.to(TimeUnit.NANOSECONDS) + 100_000,
+            TimeUnit.NANOSECONDS,
+        )
+        Files.setLastModifiedTime(
+            file.toPath(),
+            subMillisecondChange,
+        )
+        val storedLastModified = Files.getLastModifiedTime(file.toPath())
+        assumeTrue(storedLastModified != originalLastModified, "Filesystem does not retain sub-millisecond timestamps")
+        assumeTrue(storedLastModified.toMillis() == originalLastModified.toMillis())
+
+        coder.detectFileChanges()
+
+        assertTrue(
+            coder.modifiedBinaryResources.contains(file),
+            "Same-size changes must be detected from the filesystem timestamp",
+        )
     }
 
     // ==================== resource APK input reuse tests ====================


### PR DESCRIPTION
## Summary

I profiled the patching pipeline through Morphe Desktop and found that resource assembly was doing the same expensive work twice: ARSCLib re-encoded and recompressed thousands of unchanged files into `resources.apk`, then the patcher copied those entries into the output APK again.

This PR removes that redundant work:

- use the compiled resource APK directly as the output base instead of merging it back into the original APK
- reuse unchanged entries from the original archive so ARSCLib can copy their existing encoded payloads
- rebuild the manifest, resource table, and files that were actually added or changed
- preserve the existing behavior for deleted resources, package renames, raw-only patching, DEX replacement, alignment, and signing
- use high-resolution filesystem metadata and file identity to improve same-size change detection when the filesystem exposes distinguishable metadata

This does not change compression levels or patch semantics. It avoids decoding/recompressing/copying data that did not change.

## Performance

The baseline is the released Morphe Desktop v1.13.0 with patcher v1.8.0. The optimized runs use the same Desktop revision with this branch. Each comparison used the same source package, patch bundle, default patch selection, JDK, signing configuration, and temp/output disk.

| App | Baseline | This PR | Speedup | Time reduction | Time saved |
| --- | ---: | ---: | ---: | ---: | ---: |
| Piko / Instagram 439.0.0.37.89 | 250.75 s | 45.65 s | **5.49x** | **81.80%** | 205.10 s |
| YouTube 21.04.223 | 240.92 s | 120.85 s | **1.99x** | **49.84%** | 120.07 s |
| YouTube Music 9.15.51 | 84.97 s | 50.90 s | **1.67x** | **40.10%** | 34.07 s |
| Reddit 2026.14.0 | 103.13 s | 58.20 s | **1.77x** | **43.56%** | 44.93 s |
| Morphe default-app total | 429.02 s | 229.95 s | **1.87x** | **46.40%** | 199.07 s |

Piko is the strongest case: 16,695 unchanged archive entries are reused and only 6 resource inputs are rebuilt. Its patch-result JSON is byte-identical between the baseline and optimized runs (56 applied patches, no failures).

## Correctness checks

- patch-result JSON is byte-identical for baseline and optimized runs on Piko, YouTube, YouTube Music, and Reddit
- all patching, rebuilding, and signing steps completed with zero failed patches
- every optimized APK passes `apksigner verify`, `zipalign -c -P 16 4`, `aapt2 dump badging`, and `aapt2 dump resources`
- all 34 generated DEX files pass `dexdump`
- YouTube: all 16,385 resource payloads match; the only semantic DEX difference is the expected generated `PatchInfo.PATCH_TIME` value
- YouTube Music: all 5,222 resource payloads and all 10 DEX files match; the final APK differs only in nondeterministic signing data
- Reddit: all 13 DEX files match; decoding both resource APKs produces the same 4,482-file tree except for one whitespace-only text node that the old full re-encode inserted in `preferences_lite.xml`; the AAPT XML tree has the same elements and attributes
- Piko output was installed and launched successfully through the Desktop workflow

## Tests

The test suite contains 554 tests and passes with zero failures on JDK 11, 17, and 23. New coverage includes:

- compiled resource APK output-base behavior
- fallback behavior when no compiled resource APK exists
- stale DEX removal and patched DEX stream cleanup
- changed, new, deleted, and unchanged archive entries
- path-map alias restoration
- package rename handling
- same-size replacements when the filesystem exposes distinguishable replacement metadata
- sub-millisecond timestamp changes where supported by the filesystem

The existing pull-request matrix will additionally run the suite on Linux, Windows, and macOS with JDK 11, 17, and 25.

