### PR TITLE
perf: Avoid redundant fingerprint and resource work

### DIFF
--- a/src/main/kotlin/app/morphe/patcher/Fingerprint.kt
+++ b/src/main/kotlin/app/morphe/patcher/Fingerprint.kt
@@ -293,6 +293,16 @@ open class Fingerprint private constructor(
             }
         }
 
+        instructionFilterCandidates()?.let { candidates ->
+            candidates.forEach { value ->
+                val match = machAllClassMethods(value)
+                if (match != null) return match
+            }
+
+            // Exact indexed filters make this candidate set exhaustive.
+            return null
+        }
+
         // Check all classes.
         patchClasses.classMap.values.forEach { value ->
             val value = machAllClassMethods(value)
@@ -607,6 +617,9 @@ open class Fingerprint private constructor(
      */
     context(BytecodePatchContext)
     fun matchAllOrNull(): List<Match>? {
+        // matchAll is an independent search, not an extension of a cached match.
+        clearMatch()
+
         if (classFingerprint != null) {
             return matchAll(classFingerprint.classDef)
         }
@@ -651,6 +664,11 @@ open class Fingerprint private constructor(
                 // If multiple fingerprint strings are declared then duplicates matches can exist.
                 return matches.distinctBy(Match::originalMethod)
             }
+
+            instructionFilterCandidates()?.let { candidates ->
+                candidates.forEach(::machAllClassMethods)
+                return matches.distinctBy(Match::originalMethod).ifEmpty { null }
+            }
         }
 
         // Check all classes.
@@ -660,6 +678,39 @@ open class Fingerprint private constructor(
 
         return matches.ifEmpty { null }
     }
+
+    context(BytecodePatchContext)
+    private fun instructionFilterCandidates(): List<PatchClasses.ClassDefWrapper>? {
+        val filters = filters ?: return null
+        val candidateSets = filters.mapNotNull { filter -> filter.indexedCandidatesOrNull() }
+        if (candidateSets.isEmpty()) return null
+
+        val smallestCandidates = candidateSets.minBy { it.size }
+        return patchClasses.classMap.values.filter(smallestCandidates::contains)
+    }
+
+    context(BytecodePatchContext)
+    private fun InstructionFilter.indexedCandidatesOrNull(): Set<PatchClasses.ClassDefWrapper>? = when (this) {
+        is AnyInstruction -> filters.map { filter ->
+            filter.indexedCandidatesOrNull() ?: return null
+        }.flatten().toSet()
+        is LiteralFilter -> patchClasses.getClassesContainingLiteral(literalValue).orEmpty().toSet()
+        else -> exactReferencedTypesOrNull()?.flatMap { type ->
+            patchClasses.getClassesReferencingType(type).orEmpty()
+        }?.toSet()
+    }
+
+    private fun InstructionFilter.exactReferencedTypesOrNull(): Set<String>? = when (this) {
+        is MethodCallFilter -> definingClass?.takeIf(::isExactType)?.let(::setOf)
+        is FieldAccessFilter -> definingClass?.takeIf(::isExactType)?.let(::setOf)
+        is NewInstanceFilter -> typeValue.takeIf(::isExactType)?.let(::setOf)
+        is InstanceOfFilter -> typeValue.takeIf(::isExactType)?.let(::setOf)
+        is CheckCastFilter -> typeValue.takeIf(::isExactType)?.let(::setOf)
+        else -> null
+    }
+
+    private fun isExactType(type: String): Boolean =
+        type != "this" && StringComparisonType.typeDeclarationToComparison(type) == StringComparisonType.EQUALS
 
     fun patchException() = PatchException("Failed to match the fingerprint: $this")
 

--- a/src/main/kotlin/app/morphe/patcher/Fingerprint.kt
+++ b/src/main/kotlin/app/morphe/patcher/Fingerprint.kt
@@ -681,24 +681,22 @@ open class Fingerprint private constructor(
         return matches.ifEmpty { null }
     }
 
-    context(BytecodePatchContext)
+    context(patchContext: BytecodePatchContext)
     private fun instructionFilterCandidates(): List<PatchClasses.ClassDefWrapper>? {
         val filters = filters ?: return null
+        if (filters.any { it::class !in BUNDLED_INSTRUCTION_FILTERS }) return null
         val candidateSets = filters.mapNotNull { filter -> filter.indexedCandidatesOrNull() }
         if (candidateSets.isEmpty()) return null
 
         val smallestCandidates = candidateSets.minBy { it.size }
-        return patchClasses.classMap.values.filter(smallestCandidates::contains)
+        return patchContext.patchClasses.classMap.values.filter(smallestCandidates::contains)
     }
 
-    context(BytecodePatchContext)
+    context(patchContext: BytecodePatchContext)
     private fun InstructionFilter.indexedCandidatesOrNull(): Set<PatchClasses.ClassDefWrapper>? = when (this) {
-        is AnyInstruction -> filters.map { filter ->
-            filter.indexedCandidatesOrNull() ?: return null
-        }.flatten().toSet()
-        is LiteralFilter -> patchClasses.getClassesContainingLiteral(literalValue).orEmpty().toSet()
+        is LiteralFilter -> patchContext.patchClasses.getClassesContainingLiteral(literalValue).orEmpty().toSet()
         else -> exactReferencedTypesOrNull()?.flatMap { type ->
-            patchClasses.getClassesReferencingType(type).orEmpty()
+            patchContext.patchClasses.getClassesReferencingType(type).orEmpty()
         }?.toSet()
     }
 

--- a/src/main/kotlin/app/morphe/patcher/Fingerprint.kt
+++ b/src/main/kotlin/app/morphe/patcher/Fingerprint.kt
@@ -294,6 +294,16 @@ open class Fingerprint private constructor(
             }
         }
 
+        instructionFilterCandidates()?.let { candidates ->
+            candidates.forEach { value ->
+                val match = machAllClassMethods(value)
+                if (match != null) return match
+            }
+
+            // Exact indexed filters make this candidate set exhaustive.
+            return null
+        }
+
         // Check all classes.
         patchContext.patchClasses.classMap.values.forEach { value ->
             val value = machAllClassMethods(value)
@@ -609,6 +619,9 @@ open class Fingerprint private constructor(
      */
     context(patchContext: BytecodePatchContext)
     fun matchAllOrNull(): List<Match>? {
+        // matchAll is an independent search, not an extension of a cached match.
+        clearMatch()
+
         if (classFingerprint != null) {
             return matchAll(classFingerprint.classDef)
         }
@@ -653,6 +666,11 @@ open class Fingerprint private constructor(
                 // If multiple fingerprint strings are declared then duplicates matches can exist.
                 return matches.distinctBy(Match::originalMethod)
             }
+
+            instructionFilterCandidates()?.let { candidates ->
+                candidates.forEach(::machAllClassMethods)
+                return matches.distinctBy(Match::originalMethod).ifEmpty { null }
+            }
         }
 
         // Check all classes.
@@ -662,6 +680,39 @@ open class Fingerprint private constructor(
 
         return matches.ifEmpty { null }
     }
+
+    context(BytecodePatchContext)
+    private fun instructionFilterCandidates(): List<PatchClasses.ClassDefWrapper>? {
+        val filters = filters ?: return null
+        val candidateSets = filters.mapNotNull { filter -> filter.indexedCandidatesOrNull() }
+        if (candidateSets.isEmpty()) return null
+
+        val smallestCandidates = candidateSets.minBy { it.size }
+        return patchClasses.classMap.values.filter(smallestCandidates::contains)
+    }
+
+    context(BytecodePatchContext)
+    private fun InstructionFilter.indexedCandidatesOrNull(): Set<PatchClasses.ClassDefWrapper>? = when (this) {
+        is AnyInstruction -> filters.map { filter ->
+            filter.indexedCandidatesOrNull() ?: return null
+        }.flatten().toSet()
+        is LiteralFilter -> patchClasses.getClassesContainingLiteral(literalValue).orEmpty().toSet()
+        else -> exactReferencedTypesOrNull()?.flatMap { type ->
+            patchClasses.getClassesReferencingType(type).orEmpty()
+        }?.toSet()
+    }
+
+    private fun InstructionFilter.exactReferencedTypesOrNull(): Set<String>? = when (this) {
+        is MethodCallFilter -> definingClass?.takeIf(::isExactType)?.let(::setOf)
+        is FieldAccessFilter -> definingClass?.takeIf(::isExactType)?.let(::setOf)
+        is NewInstanceFilter -> typeValue.takeIf(::isExactType)?.let(::setOf)
+        is InstanceOfFilter -> typeValue.takeIf(::isExactType)?.let(::setOf)
+        is CheckCastFilter -> typeValue.takeIf(::isExactType)?.let(::setOf)
+        else -> null
+    }
+
+    private fun isExactType(type: String): Boolean =
+        type != "this" && StringComparisonType.typeDeclarationToComparison(type) == StringComparisonType.EQUALS
 
     fun patchException() = PatchException("Failed to match the fingerprint: $this")
 

--- a/src/main/kotlin/app/morphe/patcher/InstructionFilter.kt
+++ b/src/main/kotlin/app/morphe/patcher/InstructionFilter.kt
@@ -348,7 +348,7 @@ class LiteralFilter internal constructor(
     /**
      * Store the lambda value instead of calling it more than once.
      */
-    private val literalValue: Long by lazy(literal)
+    internal val literalValue: Long by lazy(literal)
 
     override fun matches(
         enclosingMethod: Method,
@@ -990,7 +990,7 @@ class NewInstanceFilter internal constructor (
     /**
      * Store the lambda value instead of calling it more than once.
      */
-    private val typeValue: String by lazy {
+    internal val typeValue: String by lazy {
         val typeValue = type()
         typeValue
     }
@@ -1074,7 +1074,7 @@ class InstanceOfFilter internal constructor(
     /**
      * Store the lambda value instead of calling it more than once.
      */
-    private val typeValue: String by lazy {
+    internal val typeValue: String by lazy {
         val typeValue = type()
         typeValue
     }
@@ -1154,7 +1154,7 @@ class CheckCastFilter internal constructor(
     /**
      * Store the lambda value instead of calling it more than once.
      */
-    private val typeValue: String by lazy {
+    internal val typeValue: String by lazy {
         val typeValue = type()
         typeValue
     }

--- a/src/main/kotlin/app/morphe/patcher/apk/ApkUtils.kt
+++ b/src/main/kotlin/app/morphe/patcher/apk/ApkUtils.kt
@@ -33,8 +33,7 @@ object ApkUtils {
     // Alignment for all other files.
     private const val DEFAULT_ALIGNMENT = 4
 
-    // Prefix for resources.
-    private const val RES_PREFIX = "res/"
+    private val dexEntryName = Regex("""classes(?:\d+)?\.dex""")
 
     private val zFileOptions =
         ZFileOptions().setAlignmentRule(
@@ -48,38 +47,31 @@ object ApkUtils {
      * Applies the [PatcherResult] to the given [apkFile].
      *
      * The order of operation is as follows:
-     * 1. Delete all resources in the target APK.
-     * 2. Merge resources.apk compiled by AAPT.
-     * 3. Write raw resources.
-     * 4. Delete resources staged for deletion.
-     * 5. Write patched dex files.
-     * 6. Realign the APK.
+     * 1. Use resources.apk compiled by AAPT as the output base, when present.
+     * 2. Write raw resources.
+     * 3. Delete resources staged for deletion.
+     * 4. Write patched dex files.
+     * 5. Realign the APK.
      *
      * @param apkFile The file to apply the patched files to.
      */
     fun PatcherResult.applyTo(apkFile: File) {
+        resources.resourcesApk?.let { resourcesApk ->
+            logger.info("Using compiled resource APK as output base")
+
+            if (resourcesApk.canonicalFile != apkFile.canonicalFile) {
+                resourcesApk.copyTo(apkFile, overwrite = true)
+            }
+        }
+
         ZFile.openReadWrite(apkFile, zFileOptions).use { targetApkZFile ->
             resources.let { resources ->
-                // Add resources compiled by AAPT.
-                resources.resourcesApk?.let { resourcesApk ->
-                    ZFile.openReadOnly(resourcesApk).use { resourcesApkZFile ->
-                        // Delete all resources in the target APK before merging the new ones.
-                        // This is necessary because the resources.apk renames resources.
-                        // So unless, the old resources are deleted, there will be orphaned resources in the APK.
-                        // It is not necessary, but for the sake of cleanliness, it is done.
-                        targetApkZFile.entries().filter { entry ->
-                            entry.centralDirectoryHeader.name.startsWith(RES_PREFIX)
-                        }.forEach(StoredEntry::delete)
-
-                        targetApkZFile.mergeFrom(resourcesApkZFile) { entry ->
-                            // Filter any dex files in case they were packaged inside resources.apk for some reason.
-                            (entry.startsWith("classes") && entry.endsWith(".dex"))
-
-                            // Filter any files that are already marked for deletion so we don't needlessly copy them,
-                            // in case they made it into the resources.apk.
-                            || entry in resources.deleteResources
-                        }
-                    }
+                // A compiled resource APK is a complete non-DEX APK. Remove any accidentally packaged DEX files
+                // before adding the final patched DEX set.
+                if (resources.resourcesApk != null) {
+                    targetApkZFile.entries().filter { entry ->
+                        entry.centralDirectoryHeader.name.matches(dexEntryName)
+                    }.forEach(StoredEntry::delete)
                 }
 
                 // Add resources not compiled by AAPT.
@@ -98,9 +90,14 @@ object ApkUtils {
             }
 
             // Run this after resource updates to ensure our dex files don't get overwritten.
-            dexFiles.forEach { dexFile ->
-                targetApkZFile.add(dexFile.name, dexFile.stream)
-                dexFile.stream.close()
+            try {
+                dexFiles.forEach { dexFile ->
+                    targetApkZFile.add(dexFile.name, dexFile.stream)
+                }
+            } finally {
+                dexFiles.forEach { dexFile ->
+                    runCatching { dexFile.stream.close() }
+                }
             }
 
             logger.info("Aligning APK")

--- a/src/main/kotlin/app/morphe/patcher/apk/ApkUtils.kt
+++ b/src/main/kotlin/app/morphe/patcher/apk/ApkUtils.kt
@@ -33,8 +33,7 @@ object ApkUtils {
     // Alignment for all other files.
     private const val DEFAULT_ALIGNMENT = 4
 
-    // Prefix for resources.
-    private const val RES_PREFIX = "res/"
+    private val dexEntryName = Regex("""classes(?:\d+)?\.dex""")
 
     private val zFileOptions =
         ZFileOptions().setAlignmentRule(
@@ -48,12 +47,11 @@ object ApkUtils {
      * Applies the [PatcherResult] to the given [apkFile].
      *
      * The order of operation is as follows:
-     * 1. Delete all resources in the target APK.
-     * 2. Merge resources.apk compiled by AAPT.
-     * 3. Write raw resources.
-     * 4. Delete resources staged for deletion.
-     * 5. Write patched dex files.
-     * 6. Realign the APK.
+     * 1. Use resources.apk compiled by AAPT as the output base, when present.
+     * 2. Write raw resources.
+     * 3. Delete resources staged for deletion.
+     * 4. Write patched dex files.
+     * 5. Realign the APK.
      *
      * [apkFile] must be a copy of the APK that was patched. The result is a set of changes
      * against that APK rather than a self-contained APK: entries a patch did not touch, such as
@@ -64,28 +62,22 @@ object ApkUtils {
      * @param apkFile A copy of the patched APK, to apply the patched files to.
      */
     fun PatcherResult.applyTo(apkFile: File) {
+        resources.resourcesApk?.let { resourcesApk ->
+            logger.info("Using compiled resource APK as output base")
+
+            if (resourcesApk.canonicalFile != apkFile.canonicalFile) {
+                resourcesApk.copyTo(apkFile, overwrite = true)
+            }
+        }
+
         ZFile.openReadWrite(apkFile, zFileOptions).use { targetApkZFile ->
             resources.let { resources ->
-                // Add resources compiled by AAPT.
-                resources.resourcesApk?.let { resourcesApk ->
-                    ZFile.openReadOnly(resourcesApk).use { resourcesApkZFile ->
-                        // Delete all resources in the target APK before merging the new ones.
-                        // This is necessary because the resources.apk renames resources.
-                        // So unless, the old resources are deleted, there will be orphaned resources in the APK.
-                        // It is not necessary, but for the sake of cleanliness, it is done.
-                        targetApkZFile.entries().filter { entry ->
-                            entry.centralDirectoryHeader.name.startsWith(RES_PREFIX)
-                        }.forEach(StoredEntry::delete)
-
-                        targetApkZFile.mergeFrom(resourcesApkZFile) { entry ->
-                            // Filter any dex files in case they were packaged inside resources.apk for some reason.
-                            (entry.startsWith("classes") && entry.endsWith(".dex"))
-
-                            // Filter any files that are already marked for deletion so we don't needlessly copy them,
-                            // in case they made it into the resources.apk.
-                            || entry in resources.deleteResources
-                        }
-                    }
+                // A compiled resource APK is a complete non-DEX APK. Remove any accidentally packaged DEX files
+                // before adding the final patched DEX set.
+                if (resources.resourcesApk != null) {
+                    targetApkZFile.entries().filter { entry ->
+                        entry.centralDirectoryHeader.name.matches(dexEntryName)
+                    }.forEach(StoredEntry::delete)
                 }
 
                 // Add resources not compiled by AAPT.
@@ -104,9 +96,14 @@ object ApkUtils {
             }
 
             // Run this after resource updates to ensure our dex files don't get overwritten.
-            dexFiles.forEach { dexFile ->
-                targetApkZFile.add(dexFile.name, dexFile.stream)
-                dexFile.stream.close()
+            try {
+                dexFiles.forEach { dexFile ->
+                    targetApkZFile.add(dexFile.name, dexFile.stream)
+                }
+            } finally {
+                dexFiles.forEach { dexFile ->
+                    runCatching { dexFile.stream.close() }
+                }
             }
 
             logger.info("Aligning APK")

--- a/src/main/kotlin/app/morphe/patcher/apk/ApkUtils.kt
+++ b/src/main/kotlin/app/morphe/patcher/apk/ApkUtils.kt
@@ -53,11 +53,8 @@ object ApkUtils {
      * 4. Write patched dex files.
      * 5. Realign the APK.
      *
-     * [apkFile] must be a copy of the APK that was patched. The result is a set of changes
-     * against that APK rather than a self-contained APK: entries a patch did not touch, such as
-     * native libraries and assets, are expected to already be present in [apkFile] and are not
-     * carried in the result. Applying this to any other file silently produces an APK missing
-     * those entries.
+     * Without a compiled resource APK, [apkFile] must be a copy of the input APK so that
+     * unchanged entries remain available. Otherwise, the compiled resource APK replaces it.
      *
      * @param apkFile A copy of the patched APK, to apply the patched files to.
      */

--- a/src/main/kotlin/app/morphe/patcher/patch/BytecodePatchContext.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/BytecodePatchContext.kt
@@ -280,7 +280,7 @@ class BytecodePatchContext internal constructor(private val config: PatcherConfi
         comparison: StringComparisonType = StringComparisonType.EQUALS
     ): List<ClassDef> {
         val result = mutableSetOf<ClassDef>()
-        patchClasses.getClassesByStringMap().forEach { (string, list) ->
+        patchClasses.getClassesByReferenceMap().forEach { (string, list) ->
             if (comparison.compare(string, literalString)) {
                 list.forEach { wrapper ->
                     result += wrapper.classDef

--- a/src/main/kotlin/app/morphe/patcher/resource/PublicXmlManager.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/PublicXmlManager.kt
@@ -16,7 +16,7 @@ class PublicXmlManager(
 ) : Closeable {
     private val logger = Logger.getLogger(this::class.java.name)
     private val resourceIds = mutableMapOf<String, Int>()
-    private val definedIds = mutableMapOf<Pair<String, String>, Int>()
+    private val definedIdsByType = mutableMapOf<String, MutableMap<String, Int>>()
     private lateinit var packageName: String
     private lateinit var packageId: String
 
@@ -57,7 +57,7 @@ class PublicXmlManager(
                                 resourceIds[typeString] = id
                             }
                             // Need to add type because it is possible to have multiple resources with the same name but different types.
-                            definedIds[Pair(typeString, nameString)] = id
+                            definedIdsByType.getOrPut(typeString) { mutableMapOf() }[nameString] = id
                         }
                     }
                 }
@@ -67,7 +67,7 @@ class PublicXmlManager(
     }
 
     fun idExists(type: String, name: String): Boolean {
-        return definedIds.contains(Pair(type, name))
+        return definedIdsByType[type]?.containsKey(name) == true
     }
 
     fun getHighestResourceIds(): Map<String, Int> {
@@ -75,7 +75,11 @@ class PublicXmlManager(
     }
 
     fun getDefinedIds(): Map<Pair<String, String>, Int> {
-        return definedIds
+        return buildMap {
+            definedIdsByType.forEach { (type, ids) ->
+                ids.forEach { (name, id) -> put(type to name, id) }
+            }
+        }
     }
 
     fun createPublicId(type: String, name: String?) {
@@ -87,7 +91,7 @@ class PublicXmlManager(
 
         val resourceId = resourceIds.getOrElse(type) { 0 } + 1
         resourceIds[type] = resourceId
-        definedIds[Pair(type, name)] = resourceId
+        definedIdsByType.getOrPut(type) { mutableMapOf() }[name] = resourceId
     }
 
     internal fun changePackageName(packageName: String) {
@@ -109,10 +113,8 @@ class PublicXmlManager(
             serializer.attribute(null, "id", packageId)
 
             // Write <public> tags for each resource ID
-            definedIds.map {
-                val (type, name) = it.key
-                val id = it.value
-                Triple(type, name, id)
+            definedIdsByType.flatMap { (type, ids) ->
+                ids.map { (name, id) -> Triple(type, name, id) }
             }.sortedBy { it.third }.forEach { (type, name, id) ->
                 serializer.startTag(null, "public")
                 serializer.attribute(null, "id", "0x${id.toString(16)}")

--- a/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
@@ -38,8 +38,10 @@ import org.w3c.dom.Element
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.attribute.FileTime
 import java.util.logging.Logger
-import kotlin.time.measureTimedValue
+import kotlin.time.measureTime
 
 internal class ArsclibResourceCoder(
     internal val workingDir: File,
@@ -62,10 +64,16 @@ internal class ArsclibResourceCoder(
     internal val deletedFiles = mutableSetOf<String>()
 
     /**
-     * Snapshot of file metadata (modification time and size) captured after decoding resources.
-     * Used to detect which files were added or modified between decoding and encoding.
+     * Snapshot of file metadata and identity captured after decoding resources.
+     * High-resolution timestamps and file keys catch same-size rewrites and replacement files without rereading every
+     * decoded resource payload.
      */
-    internal data class FileSnapshot(val lastModified: Long, val size: Long)
+    internal class FileSnapshot(
+        val creationTime: FileTime,
+        val lastModified: FileTime,
+        val size: Long,
+        val fileKey: Any?,
+    )
     internal var fileSnapshotCache: Map<File, FileSnapshot> = emptyMap()
     internal var pathMap: PathMap = PathMap.EMPTY
 
@@ -75,10 +83,10 @@ internal class ArsclibResourceCoder(
     internal fun buildFileSnapshot(): Map<File, FileSnapshot> {
         val snapshot = mutableMapOf<File, FileSnapshot>()
         workingDir.resolve("resources").walkTopDown().filter { it.isFile }.forEach { file ->
-            snapshot[file] = FileSnapshot(file.lastModified(), file.length())
+            snapshot[file] = file.snapshot()
         }
         workingDir.resolve("root").walkTopDown().filter { it.isFile }.forEach { file ->
-            snapshot[file] = FileSnapshot(file.lastModified(), file.length())
+            snapshot[file] = file.snapshot()
         }
         return snapshot
     }
@@ -98,7 +106,7 @@ internal class ArsclibResourceCoder(
                 if (excludedPaths.contains(relativePath)) return@forEach
 
                 val cached = fileSnapshotCache[file]
-                if (cached == null || file.lastModified() != cached.lastModified || file.length() != cached.size) {
+                if (file.differsFrom(cached)) {
                     modifiedResResources.add(file)
                 }
             }
@@ -106,7 +114,7 @@ internal class ArsclibResourceCoder(
 
         otherResourcesRootDirectory.walkTopDown().filter { it.isFile }.forEach { file ->
             val cached = fileSnapshotCache[file]
-            if (cached == null || file.lastModified() != cached.lastModified || file.length() != cached.size) {
+            if (file.differsFrom(cached)) {
                 modifiedBinaryResources.add(file)
             }
         }
@@ -298,9 +306,9 @@ internal class ArsclibResourceCoder(
         val encoder = ApkModuleXmlEncoder()
         encoder.apkModule.use { loadedModule ->
             loadedModule.setPreferredFramework(lazyPackageInfo.value.frameworkVersion)
-            val scanDuration = measureTimedValue {
+            val scanDuration = measureTime {
                 encoder.scanDirectory(workingDir)
-            }.duration
+            }
 
             ApkModule.loadApkFile(apkFile).use { originalModule ->
                 val changedEntries = changedArchiveEntries(originalPackageName != newPackageName)
@@ -312,9 +320,9 @@ internal class ArsclibResourceCoder(
                             "rebuilding $rebuiltEntries entries",
                 )
 
-                val writeDuration = measureTimedValue {
+                val writeDuration = measureTime {
                     loadedModule.writeApk(outputApk)
-                }.duration
+                }
 
                 logger.info("Resource APK timings: scan=$scanDuration, write=$writeDuration")
             }
@@ -382,6 +390,25 @@ internal class ArsclibResourceCoder(
 
         val alias = basePath.relativize(filePath).toString().replace(File.separatorChar, '/')
         return pathMap.getOriginalName(alias) ?: alias
+    }
+
+    private fun File.snapshot(): FileSnapshot {
+        val attributes = Files.readAttributes(toPath(), BasicFileAttributes::class.java)
+        return FileSnapshot(
+            attributes.creationTime(),
+            attributes.lastModifiedTime(),
+            attributes.size(),
+            attributes.fileKey(),
+        )
+    }
+
+    private fun File.differsFrom(snapshot: FileSnapshot?): Boolean {
+        if (snapshot == null) return true
+        val attributes = Files.readAttributes(toPath(), BasicFileAttributes::class.java)
+        return attributes.creationTime() != snapshot.creationTime ||
+                attributes.lastModifiedTime() != snapshot.lastModified ||
+                attributes.size() != snapshot.size ||
+                attributes.fileKey() != snapshot.fileKey
     }
 
     override fun getOtherResourceFiles(outputDir: File, resourceMode: ResourceMode): File? {

--- a/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
@@ -65,8 +65,8 @@ internal class ArsclibResourceCoder(
 
     /**
      * Snapshot of file metadata and identity captured after decoding resources.
-     * High-resolution timestamps and file keys catch same-size rewrites and replacement files without rereading every
-     * decoded resource payload.
+     * High-resolution timestamps and file keys improve same-size change detection when the filesystem exposes
+     * distinguishable metadata, without rereading every decoded resource payload.
      */
     internal class FileSnapshot(
         val creationTime: FileTime,

--- a/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
@@ -276,13 +276,14 @@ internal class ArsclibResourceCoder(
                 packageDirectories,
             ).process()
 
-            PackageRenamingProcessor(
+            val renamedResources = PackageRenamingProcessor(
                 this@ArsclibResourceCoder::getFile,
                 publicXmlManager,
                 packageDirectories,
                 originalPackageName,
                 newPackageName
             ).process()
+            modifiedResResources += renamedResources
 
             // Post process all aapt:attr macros in XML files.
             AaptMacroProcessor(
@@ -311,7 +312,7 @@ internal class ArsclibResourceCoder(
             }
 
             ApkModule.loadApkFile(apkFile).use { originalModule ->
-                val changedEntries = changedArchiveEntries(originalPackageName != newPackageName)
+                val changedEntries = changedArchiveEntries()
                 val reusedEntries = reuseUnchangedArchiveEntries(originalModule, loadedModule, changedEntries)
                 val rebuiltEntries = loadedModule.zipEntryMap.listInputSources().size - reusedEntries
 
@@ -334,7 +335,7 @@ internal class ArsclibResourceCoder(
     /**
      * Returns original APK entry names which must be rebuilt from the decoded resource tree.
      */
-    internal fun changedArchiveEntries(packageRenamed: Boolean): Set<String> = buildSet {
+    internal fun changedArchiveEntries(): Set<String> = buildSet {
         add("AndroidManifest.xml")
         add("resources.arsc")
 
@@ -348,15 +349,6 @@ internal class ArsclibResourceCoder(
             file.archivePathRelativeToOrNull(otherResourcesRootDirectory)?.let(::add)
         }
 
-        // PackageRenamingProcessor may rewrite resource XMLs which patches did not directly touch.
-        // Rebuild all compiled resources when that processor ran, while still reusing unchanged APK-root files.
-        if (packageRenamed) {
-            packageDirectories.values.forEach { packageDirectory ->
-                packageDirectory.resolve("res").walkTopDown().filter { it.isFile }.forEach { file ->
-                    file.archivePathRelativeToOrNull(packageDirectory)?.let(::add)
-                }
-            }
-        }
     }
 
     /**

--- a/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
@@ -28,6 +28,7 @@ import com.reandroid.apk.ApkModule
 import com.reandroid.apk.ApkModuleRawDecoder
 import com.reandroid.apk.ApkModuleXmlDecoder
 import com.reandroid.apk.ApkModuleXmlEncoder
+import com.reandroid.archive.InputSource
 import com.reandroid.archive.block.ApkSignatureBlock
 import com.reandroid.arsc.coder.CoderSetting
 import com.reandroid.arsc.coder.xml.AaptXmlStringDecoder
@@ -38,6 +39,7 @@ import java.io.File
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 import java.util.logging.Logger
+import kotlin.time.measureTimedValue
 
 internal class ArsclibResourceCoder(
     internal val workingDir: File,
@@ -296,11 +298,90 @@ internal class ArsclibResourceCoder(
         val encoder = ApkModuleXmlEncoder()
         encoder.apkModule.use { loadedModule ->
             loadedModule.setPreferredFramework(lazyPackageInfo.value.frameworkVersion)
-            encoder.scanDirectory(workingDir)
-            loadedModule.writeApk(outputApk)
+            val scanDuration = measureTimedValue {
+                encoder.scanDirectory(workingDir)
+            }.duration
+
+            ApkModule.loadApkFile(apkFile).use { originalModule ->
+                val changedEntries = changedArchiveEntries(originalPackageName != newPackageName)
+                val reusedEntries = reuseUnchangedArchiveEntries(originalModule, loadedModule, changedEntries)
+                val rebuiltEntries = loadedModule.zipEntryMap.listInputSources().size - reusedEntries
+
+                logger.info(
+                    "Resource APK inputs: reusing $reusedEntries unchanged archive entries, " +
+                            "rebuilding $rebuiltEntries entries",
+                )
+
+                val writeDuration = measureTimedValue {
+                    loadedModule.writeApk(outputApk)
+                }.duration
+
+                logger.info("Resource APK timings: scan=$scanDuration, write=$writeDuration")
+            }
         }
 
         return outputApk
+    }
+
+    /**
+     * Returns original APK entry names which must be rebuilt from the decoded resource tree.
+     */
+    internal fun changedArchiveEntries(packageRenamed: Boolean): Set<String> = buildSet {
+        add("AndroidManifest.xml")
+        add("resources.arsc")
+
+        modifiedResResources.forEach { file ->
+            packageDirectories.values.firstNotNullOfOrNull { packageDirectory ->
+                file.archivePathRelativeToOrNull(packageDirectory)
+            }?.let(::add)
+        }
+
+        modifiedBinaryResources.forEach { file ->
+            file.archivePathRelativeToOrNull(otherResourcesRootDirectory)?.let(::add)
+        }
+
+        // PackageRenamingProcessor may rewrite resource XMLs which patches did not directly touch.
+        // Rebuild all compiled resources when that processor ran, while still reusing unchanged APK-root files.
+        if (packageRenamed) {
+            packageDirectories.values.forEach { packageDirectory ->
+                packageDirectory.resolve("res").walkTopDown().filter { it.isFile }.forEach { file ->
+                    file.archivePathRelativeToOrNull(packageDirectory)?.let(::add)
+                }
+            }
+        }
+    }
+
+    /**
+     * Replaces unchanged filesystem-backed encoder inputs with archive-backed inputs from [originalModule].
+     * ARSCLib can raw-copy those entries in their existing compressed form instead of reopening and recompressing
+     * every extracted file.
+     */
+    internal fun reuseUnchangedArchiveEntries(
+        originalModule: ApkModule,
+        encodedModule: ApkModule,
+        changedEntries: Set<String>,
+    ): Int {
+        val encodedEntries = encodedModule.zipEntryMap
+        var reusedEntries = 0
+
+        originalModule.zipEntryMap.listInputSources().forEach { originalSource: InputSource ->
+            val entryName = originalSource.alias
+            if (entryName !in changedEntries && encodedEntries.contains(entryName)) {
+                encodedEntries.add(originalSource)
+                reusedEntries++
+            }
+        }
+
+        return reusedEntries
+    }
+
+    private fun File.archivePathRelativeToOrNull(baseDirectory: File): String? {
+        val filePath = absoluteFile.toPath().normalize()
+        val basePath = baseDirectory.absoluteFile.toPath().normalize()
+        if (!filePath.startsWith(basePath)) return null
+
+        val alias = basePath.relativize(filePath).toString().replace(File.separatorChar, '/')
+        return pathMap.getOriginalName(alias) ?: alias
     }
 
     override fun getOtherResourceFiles(outputDir: File, resourceMode: ResourceMode): File? {

--- a/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
@@ -5,7 +5,6 @@
 
 package app.morphe.patcher.resource.coder
 
-import kotlin.time.measureTimedValue
 import com.reandroid.archive.InputSource
 import app.morphe.patcher.PackageMetadata
 import app.morphe.patcher.Patcher
@@ -44,7 +43,10 @@ import org.w3c.dom.Element
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.attribute.FileTime
 import java.util.logging.Logger
+import kotlin.time.measureTime
 
 /**
  * A mobile country code and a mobile network code are three digits, so a device never reports one
@@ -95,10 +97,16 @@ internal class ArsclibResourceCoder(
     internal val deletedFiles = mutableSetOf<String>()
 
     /**
-     * Snapshot of file metadata (modification time and size) captured after decoding resources.
-     * Used to detect which files were added or modified between decoding and encoding.
+     * Snapshot of file metadata and identity captured after decoding resources.
+     * High-resolution timestamps and file keys catch same-size rewrites and replacement files without rereading every
+     * decoded resource payload.
      */
-    internal data class FileSnapshot(val lastModified: Long, val size: Long)
+    internal class FileSnapshot(
+        val creationTime: FileTime,
+        val lastModified: FileTime,
+        val size: Long,
+        val fileKey: Any?,
+    )
     internal var fileSnapshotCache: MutableMap<String, FileSnapshot> = mutableMapOf()
 
     /**
@@ -153,7 +161,7 @@ internal class ArsclibResourceCoder(
         val snapshot = mutableMapOf<String, FileSnapshot>()
         sequenceOf(workingDir.resolve("resources"), otherResourcesRootDirectory).forEach { dir ->
             dir.walkTopDown().filter { it.isFile }.forEach { file ->
-                snapshot[pathKey(file)] = FileSnapshot(file.lastModified(), file.length())
+                snapshot[pathKey(file)] = file.snapshot()
             }
         }
         return snapshot
@@ -174,7 +182,7 @@ internal class ArsclibResourceCoder(
                 if (excludedPaths.contains(relativePath)) return@forEach
 
                 val cached = fileSnapshotCache[pathKey(file)]
-                if (cached == null || file.lastModified() != cached.lastModified || file.length() != cached.size) {
+                if (file.differsFrom(cached)) {
                     modifiedResResources.add(file)
                 }
             }
@@ -191,7 +199,7 @@ internal class ArsclibResourceCoder(
                 return@forEach
             }
             val cached = fileSnapshotCache[pathKey(file)]
-            if (cached == null || file.lastModified() != cached.lastModified || file.length() != cached.size) {
+            if (file.differsFrom(cached)) {
                 modifiedBinaryResources.add(file)
             }
         }
@@ -494,10 +502,10 @@ internal class ArsclibResourceCoder(
             val encoder = ApkModuleXmlEncoder()
             encoder.apkModule.use { loadedModule ->
                 loadedModule.setPreferredFramework(lazyPackageInfo.value.frameworkVersion)
-                val scanDuration = measureTimedValue {
+                val scanDuration = measureTime {
                     encoder.scanDirectory(workingDir)
                     loadedModule.encodePatchedConfigurations(patchedConfigurations)
-                }.duration
+                }
 
                 ApkModule.loadApkFile(apkFile).use { originalModule ->
                     val changedEntries = changedArchiveEntries(originalPackageName != newPackageName)
@@ -509,9 +517,9 @@ internal class ArsclibResourceCoder(
                                 "rebuilding $rebuiltEntries entries",
                     )
 
-                    val writeDuration = measureTimedValue {
+                    val writeDuration = measureTime {
                         loadedModule.writeApk(outputApk)
-                    }.duration
+                    }
 
                     logger.info("Resource APK timings: scan=$scanDuration, write=$writeDuration")
                 }
@@ -727,6 +735,25 @@ internal class ArsclibResourceCoder(
     private fun qualifiersOf(resourceDirectory: File): String {
         val separator = resourceDirectory.name.indexOf('-')
         return if (separator > 0) resourceDirectory.name.substring(separator) else ""
+    }
+
+    private fun File.snapshot(): FileSnapshot {
+        val attributes = Files.readAttributes(toPath(), BasicFileAttributes::class.java)
+        return FileSnapshot(
+            attributes.creationTime(),
+            attributes.lastModifiedTime(),
+            attributes.size(),
+            attributes.fileKey(),
+        )
+    }
+
+    private fun File.differsFrom(snapshot: FileSnapshot?): Boolean {
+        if (snapshot == null) return true
+        val attributes = Files.readAttributes(toPath(), BasicFileAttributes::class.java)
+        return attributes.creationTime() != snapshot.creationTime ||
+                attributes.lastModifiedTime() != snapshot.lastModified ||
+                attributes.size() != snapshot.size ||
+                attributes.fileKey() != snapshot.fileKey
     }
 
     override fun getOtherResourceFiles(outputDir: File, resourceMode: ResourceMode): File? {
@@ -957,7 +984,7 @@ internal class ArsclibResourceCoder(
         // filesystem timestamp tick, and same-length edits would otherwise read as unchanged.
         lazilyExtractedRootFiles[pathKey(destination)] =
             ExtractedRootFile(destination.length(), destination.readBytes().contentHashCode())
-        fileSnapshotCache[pathKey(destination)] = FileSnapshot(destination.lastModified(), destination.length())
+        fileSnapshotCache[pathKey(destination)] = destination.snapshot()
         logger.fine("Extracted root entry on demand: $apkPath")
     }
 

--- a/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
@@ -551,7 +551,6 @@ internal class ArsclibResourceCoder(
         modifiedBinaryResources.forEach { file ->
             file.archivePathRelativeToOrNull(otherResourcesRootDirectory)?.let(::add)
         }
-
     }
 
     /**

--- a/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
@@ -5,6 +5,8 @@
 
 package app.morphe.patcher.resource.coder
 
+import kotlin.time.measureTimedValue
+import com.reandroid.archive.InputSource
 import app.morphe.patcher.PackageMetadata
 import app.morphe.patcher.Patcher
 import app.morphe.patcher.PatcherResult
@@ -492,9 +494,27 @@ internal class ArsclibResourceCoder(
             val encoder = ApkModuleXmlEncoder()
             encoder.apkModule.use { loadedModule ->
                 loadedModule.setPreferredFramework(lazyPackageInfo.value.frameworkVersion)
-                encoder.scanDirectory(workingDir)
-                loadedModule.encodePatchedConfigurations(patchedConfigurations)
-                loadedModule.writeApk(outputApk)
+                val scanDuration = measureTimedValue {
+                    encoder.scanDirectory(workingDir)
+                    loadedModule.encodePatchedConfigurations(patchedConfigurations)
+                }.duration
+
+                ApkModule.loadApkFile(apkFile).use { originalModule ->
+                    val changedEntries = changedArchiveEntries(originalPackageName != newPackageName)
+                    val reusedEntries = reuseUnchangedArchiveEntries(originalModule, loadedModule, changedEntries)
+                    val rebuiltEntries = loadedModule.zipEntryMap.listInputSources().size - reusedEntries
+
+                    logger.info(
+                        "Resource APK inputs: reusing $reusedEntries unchanged archive entries, " +
+                                "rebuilding $rebuiltEntries entries",
+                    )
+
+                    val writeDuration = measureTimedValue {
+                        loadedModule.writeApk(outputApk)
+                    }.duration
+
+                    logger.info("Resource APK timings: scan=$scanDuration, write=$writeDuration")
+                }
             }
         } finally {
             patchedConfigurations.forEach { it.restore() }
@@ -502,6 +522,67 @@ internal class ArsclibResourceCoder(
         }
 
         return outputApk
+    }
+
+    /**
+     * Returns original APK entry names which must be rebuilt from the decoded resource tree.
+     */
+    internal fun changedArchiveEntries(packageRenamed: Boolean): Set<String> = buildSet {
+        add("AndroidManifest.xml")
+        add("resources.arsc")
+
+        modifiedResResources.forEach { file ->
+            packageDirectories.values.firstNotNullOfOrNull { packageDirectory ->
+                file.archivePathRelativeToOrNull(packageDirectory)
+            }?.let(::add)
+        }
+
+        modifiedBinaryResources.forEach { file ->
+            file.archivePathRelativeToOrNull(otherResourcesRootDirectory)?.let(::add)
+        }
+
+        // PackageRenamingProcessor may rewrite resource XMLs which patches did not directly touch.
+        // Rebuild all compiled resources when that processor ran, while still reusing unchanged APK-root files.
+        if (packageRenamed) {
+            packageDirectories.values.forEach { packageDirectory ->
+                packageDirectory.resolve("res").walkTopDown().filter { it.isFile }.forEach { file ->
+                    file.archivePathRelativeToOrNull(packageDirectory)?.let(::add)
+                }
+            }
+        }
+    }
+
+    /**
+     * Replaces unchanged filesystem-backed encoder inputs with archive-backed inputs from [originalModule].
+     * ARSCLib can raw-copy those entries in their existing compressed form instead of reopening and recompressing
+     * every extracted file.
+     */
+    internal fun reuseUnchangedArchiveEntries(
+        originalModule: ApkModule,
+        encodedModule: ApkModule,
+        changedEntries: Set<String>,
+    ): Int {
+        val encodedEntries = encodedModule.zipEntryMap
+        var reusedEntries = 0
+
+        originalModule.zipEntryMap.listInputSources().forEach { originalSource: InputSource ->
+            val entryName = originalSource.alias
+            if (entryName !in changedEntries && encodedEntries.contains(entryName)) {
+                encodedEntries.add(originalSource)
+                reusedEntries++
+            }
+        }
+
+        return reusedEntries
+    }
+
+    private fun File.archivePathRelativeToOrNull(baseDirectory: File): String? {
+        val filePath = absoluteFile.toPath().normalize()
+        val basePath = baseDirectory.absoluteFile.toPath().normalize()
+        if (!filePath.startsWith(basePath)) return null
+
+        val alias = basePath.relativize(filePath).toString().replace(File.separatorChar, '/')
+        return pathMap.getOriginalName(alias) ?: alias
     }
 
     /**

--- a/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
@@ -468,13 +468,14 @@ internal class ArsclibResourceCoder(
                 packageDirectories,
             ).process()
 
-            PackageRenamingProcessor(
+            val renamedResources = PackageRenamingProcessor(
                 this@ArsclibResourceCoder::getFile,
                 publicXmlManager,
                 packageDirectories,
                 originalPackageName,
                 newPackageName
             ).process()
+            modifiedResResources += renamedResources
 
             // Post process all aapt:attr macros in XML files.
             AaptMacroProcessor(
@@ -507,7 +508,7 @@ internal class ArsclibResourceCoder(
                 }
 
                 ApkModule.loadApkFile(apkFile).use { originalModule ->
-                    val changedEntries = changedArchiveEntries(originalPackageName != newPackageName)
+                    val changedEntries = changedArchiveEntries()
                     val reusedEntries = reuseUnchangedArchiveEntries(originalModule, loadedModule, changedEntries)
                     val rebuiltEntries = loadedModule.zipEntryMap.listInputSources().size - reusedEntries
 
@@ -534,7 +535,7 @@ internal class ArsclibResourceCoder(
     /**
      * Returns original APK entry names which cannot be reused.
      */
-    internal fun changedArchiveEntries(packageRenamed: Boolean): Set<String> = buildSet {
+    internal fun changedArchiveEntries(): Set<String> = buildSet {
         add("AndroidManifest.xml")
         add("resources.arsc")
         addAll(deletedFiles)
@@ -551,15 +552,6 @@ internal class ArsclibResourceCoder(
             file.archivePathRelativeToOrNull(otherResourcesRootDirectory)?.let(::add)
         }
 
-        // PackageRenamingProcessor may rewrite resource XMLs which patches did not directly touch.
-        // Rebuild all compiled resources when that processor ran, while still reusing unchanged APK-root files.
-        if (packageRenamed) {
-            packageDirectories.values.forEach { packageDirectory ->
-                packageDirectory.resolve("res").walkTopDown().filter { it.isFile }.forEach { file ->
-                    file.archivePathRelativeToOrNull(packageDirectory)?.let(::add)
-                }
-            }
-        }
     }
 
     /**

--- a/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
@@ -5,7 +5,6 @@
 
 package app.morphe.patcher.resource.coder
 
-import com.reandroid.archive.InputSource
 import app.morphe.patcher.PackageMetadata
 import app.morphe.patcher.Patcher
 import app.morphe.patcher.PatcherResult
@@ -30,6 +29,7 @@ import com.reandroid.apk.ApkModule
 import com.reandroid.apk.ApkModuleRawDecoder
 import com.reandroid.apk.ApkModuleXmlDecoder
 import com.reandroid.apk.ApkModuleXmlEncoder
+import com.reandroid.archive.InputSource
 import com.reandroid.archive.block.ApkSignatureBlock
 import com.reandroid.arsc.chunk.PackageBlock
 import com.reandroid.arsc.coder.CoderSetting
@@ -111,10 +111,9 @@ internal class ArsclibResourceCoder(
 
     /**
      * Native libraries are left in the input APK instead of being staged to disk:
-     * [ApkUtils.applyTo] rebuilds the output from a copy of that same APK, so every unchanged
-     * entry is already present and correct in the target. They are extracted only when a patch
-     * asks for one by path, through [getFile]; every other root entry is staged during decode,
-     * because a patch that discovers files by walking the directory can only see what is there.
+     * [reuseUnchangedArchiveEntries] carries them into the compiled resource APK without extraction.
+     * They are extracted through [getFile] only when requested. Other root entries are staged
+     * during decode so patches can find them by walking the directory.
      */
     private val lazilyExtractedRootFiles = mutableMapOf<String, ExtractedRootFile>()
 
@@ -533,11 +532,14 @@ internal class ArsclibResourceCoder(
     }
 
     /**
-     * Returns original APK entry names which must be rebuilt from the decoded resource tree.
+     * Returns original APK entry names which cannot be reused.
      */
     internal fun changedArchiveEntries(packageRenamed: Boolean): Set<String> = buildSet {
         add("AndroidManifest.xml")
         add("resources.arsc")
+        addAll(deletedFiles)
+        addAll(strippedLibraries)
+        addAll(relocatedRootFiles.values)
 
         modifiedResResources.forEach { file ->
             packageDirectories.values.firstNotNullOfOrNull { packageDirectory ->
@@ -561,9 +563,8 @@ internal class ArsclibResourceCoder(
     }
 
     /**
-     * Replaces unchanged filesystem-backed encoder inputs with archive-backed inputs from [originalModule].
-     * ARSCLib can raw-copy those entries in their existing compressed form instead of reopening and recompressing
-     * every extracted file.
+     * Reuses unchanged archive entries, including root files omitted by the encoder.
+     * ARSCLib copies their compressed data without recompressing it.
      */
     internal fun reuseUnchangedArchiveEntries(
         originalModule: ApkModule,
@@ -575,7 +576,10 @@ internal class ArsclibResourceCoder(
 
         originalModule.zipEntryMap.listInputSources().forEach { originalSource: InputSource ->
             val entryName = originalSource.alias
-            if (entryName !in changedEntries && encodedEntries.contains(entryName)) {
+            val alias = aliasOf(entryName)
+            val rootEntry = !stagesRootEntry(alias) ||
+                    pathKey(otherResourcesRootDirectory.resolve(alias)) in fileSnapshotCache
+            if (entryName !in changedEntries && (encodedEntries.contains(entryName) || rootEntry)) {
                 encodedEntries.add(originalSource)
                 reusedEntries++
             }

--- a/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
@@ -98,8 +98,8 @@ internal class ArsclibResourceCoder(
 
     /**
      * Snapshot of file metadata and identity captured after decoding resources.
-     * High-resolution timestamps and file keys catch same-size rewrites and replacement files without rereading every
-     * decoded resource payload.
+     * High-resolution timestamps and file keys improve same-size change detection when the filesystem exposes
+     * distinguishable metadata, without rereading every decoded resource payload.
      */
     internal class FileSnapshot(
         val creationTime: FileTime,

--- a/src/main/kotlin/app/morphe/patcher/resource/processor/PackageRenamingProcessor.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/processor/PackageRenamingProcessor.kt
@@ -22,10 +22,11 @@ internal class PackageRenamingProcessor(
     private val logger = Logger.getLogger(PackageRenamingProcessor::class.java.name)
     private val regex = Regex("^[@?]$originalPackageName:.*")
 
-    fun process() {
-        if (originalPackageName == newPackageName) return
+    fun process(): Set<File> {
+        if (originalPackageName == newPackageName) return emptySet()
 
         logger.info("Post-processing package name change")
+        val modifiedFiles = mutableSetOf<File>()
 
         // Update public.xml package
         publicXmlManager.changePackageName(newPackageName)
@@ -41,14 +42,17 @@ internal class PackageRenamingProcessor(
         packageDirectories.filter { it.key != originalPackageName }.forEach { (resPackageName, rootDir) ->
             rootDir.resolve("res").listFiles { it.isDirectory }?.forEach { dir ->
                 dir.listFiles { it.extension == "xml" && it.name != "strings.xml" }?.forEach { file ->
-                    processFile(file)
+                    if (processFile(file)) modifiedFiles += file
                 }
             }
         }
+
+        return modifiedFiles
     }
 
-    private fun processFile(file: File) {
+    private fun processFile(file: File): Boolean {
         val tempFile = File(file.parentFile, file.name + ".tmp")
+        var changed = false
 
         file.parseXml { parser ->
             tempFile.writeXml { serializer ->
@@ -65,6 +69,7 @@ internal class PackageRenamingProcessor(
                                 var newValue = value
                                 if (regex.matches(value)) {
                                     newValue = value.replace(originalPackageName, newPackageName)
+                                    changed = true
                                 }
                                 Triple(ns, name, newValue)
                             })
@@ -76,6 +81,7 @@ internal class PackageRenamingProcessor(
                             var text = parser.text
                             if (regex.matches(text)) {
                                 text = text.replace(originalPackageName, newPackageName)
+                                changed = true
                             }
                             serializer.text(text)
                         }
@@ -90,6 +96,11 @@ internal class PackageRenamingProcessor(
             }
         }
 
-        tempFile.safelyMoveTo(file)
+        if (changed) {
+            tempFile.safelyMoveTo(file)
+        } else {
+            tempFile.delete()
+        }
+        return changed
     }
 }

--- a/src/main/kotlin/app/morphe/patcher/resource/processor/ResourceIdProcessor.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/processor/ResourceIdProcessor.kt
@@ -48,8 +48,9 @@ internal class ResourceIdProcessor(
 
         createPublicIdsFromValuesXml(get("res/values/ids.xml"))
 
-        // Step 3: Ensure all other resources have a public ID
-        // TODO: Only enumerate through files that have been modified by patches.
+        // Ensure every file-based resource has a public ID. ARSCLib can decode synthetic inline-AAPT
+        // resources which are not initially present in public.xml, so this must retain filesystem order:
+        // newly added patch resource IDs are assigned after those synthetic entries.
         for (type in fileResourceTypes) {
             val directories = resDirectories.filter { it.name.startsWith(type) }
             for (dir in directories) {

--- a/src/main/kotlin/app/morphe/patcher/resource/processor/StringsXmlProcessor.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/processor/StringsXmlProcessor.kt
@@ -24,18 +24,20 @@ abstract internal class StringsXmlProcessor(
     fun process() {
         logger.info(logString)
 
-        packageDirectories.forEach { (resPackageName, rootDir) ->
-            rootDir.resolve("res").listFiles { it.isDirectory }?.forEach { dir ->
-                // TODO Strings declared in arrays.xml may also need unescaping of string literals.
-                dir.listFiles { it.name == "strings.xml" }?.forEach { file ->
-                    val path = "res/${dir.name}/${file.name}"
-                    logger.fine { "Processing $path" }
-
-                    val targetFile = get(path, resPackageName)
-                    processFile(targetFile)
+        val stringFiles = buildList {
+            packageDirectories.forEach { (resPackageName, rootDir) ->
+                rootDir.resolve("res").listFiles { it.isDirectory }?.forEach { dir ->
+                    // TODO Strings declared in arrays.xml may also need unescaping of string literals.
+                    dir.listFiles { it.name == "strings.xml" }?.forEach { file ->
+                        val path = "res/${dir.name}/${file.name}"
+                        logger.fine { "Processing $path" }
+                        add(get(path, resPackageName))
+                    }
                 }
             }
         }
+
+        stringFiles.parallelStream().forEach(::processFile)
     }
 
     private fun processFile(file: File) {

--- a/src/main/kotlin/app/morphe/patcher/resource/processor/StringsXmlSanitizeProcessor.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/processor/StringsXmlSanitizeProcessor.kt
@@ -23,12 +23,21 @@ internal class StringsXmlSanitizeProcessor(
     fun process() {
         logger.info("Sanitizing unpatched strings")
 
-        packageDirectories.forEach { (_, rootDir) ->
-            rootDir.resolve("res").listFiles { it.isDirectory }?.forEach { dir ->
-                dir.listFiles { it.name == "strings.xml" }?.forEach { file ->
-                    val rawXml = file.readText(Charsets.UTF_8)
-                    file.writeText(sanitizeXmlText(rawXml), Charsets.UTF_8)
+        val stringFiles = buildList {
+            packageDirectories.forEach { (_, rootDir) ->
+                rootDir.resolve("res").listFiles { it.isDirectory }?.forEach { dir ->
+                    dir.listFiles { it.name == "strings.xml" }?.forEach { file ->
+                        add(file)
+                    }
                 }
+            }
+        }
+
+        stringFiles.parallelStream().forEach { file ->
+            val rawXml = file.readText(Charsets.UTF_8)
+            val sanitizedXml = sanitizeXmlText(rawXml)
+            if (sanitizedXml !== rawXml) {
+                file.writeText(sanitizedXml, Charsets.UTF_8)
             }
         }
     }
@@ -52,14 +61,45 @@ internal fun sanitizeXmlText(input: String): String {
                 (code in 0xE000..0xFFFD) ||
                 (code in 0x10000..0x10FFFF)
 
-    // Remove invalid numeric character references like &#65535;
-    val cleanedEntities = input.replace(Regex("&#(\\d+);")) { match ->
-        val code = match.groupValues[1].toInt()
-        if (isValidXmlChar(code)) match.value else ""
+    // Most strings.xml files are valid. Scan once and allocate only if an invalid literal or numeric
+    // reference is encountered. Code-point iteration also preserves valid supplementary Unicode characters.
+    var output: StringBuilder? = null
+    var index = 0
+    while (index < input.length) {
+        if (input[index] == '&' && index + 2 < input.length && input[index + 1] == '#') {
+            val semicolon = input.indexOf(';', index + 2)
+            if (semicolon >= 0) {
+                val digitsStart = index + 2
+                var numeric = digitsStart < semicolon
+                var digitIndex = digitsStart
+                while (numeric && digitIndex < semicolon) {
+                    numeric = input[digitIndex].isDigit()
+                    digitIndex++
+                }
+                if (numeric) {
+                    val value = input.substring(digitsStart, semicolon).toLongOrNull()
+                    if (value == null || value > Int.MAX_VALUE || !isValidXmlChar(value.toInt())) {
+                        if (output == null) {
+                            output = StringBuilder(input.length).append(input, 0, index)
+                        }
+                        index = semicolon + 1
+                        continue
+                    }
+                }
+            }
+        }
+
+        val codePoint = Character.codePointAt(input, index)
+        val charCount = Character.charCount(codePoint)
+        if (isValidXmlChar(codePoint)) {
+            output?.append(input, index, index + charCount)
+        } else if (output == null) {
+            output = StringBuilder(input.length).append(input, 0, index)
+        }
+        index += charCount
     }
 
-    // Remove invalid literal unicode.
-    return cleanedEntities.filter { ch -> isValidXmlChar(ch.code) }
+    return output?.toString() ?: input
 }
 
 internal fun Document.toXmlString(): String {

--- a/src/main/kotlin/app/morphe/patcher/util/PatchClasses.kt
+++ b/src/main/kotlin/app/morphe/patcher/util/PatchClasses.kt
@@ -14,7 +14,11 @@ import app.morphe.patcher.util.proxy.mutableTypes.MutableClass
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.ClassDef
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.WideLiteralInstruction
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.iface.reference.StringReference
+import com.android.tools.smali.dexlib2.iface.reference.TypeReference
 import java.util.LinkedList
 
 /**
@@ -39,6 +43,12 @@ internal class PatchClasses internal constructor(
          */
         var classDef: ClassDef,
     ) {
+        /** Sorted hashes of class types referenced by instructions in this class. */
+        var referencedTypeHashes: IntArray? = null
+
+        /** Sorted literal values used by instructions in this class. */
+        var literalValues: LongArray? = null
+
         fun getMutableClass(): MutableClass {
             if (classDef !is MutableClass) {
                 classDef = MutableClass(classDef)
@@ -47,30 +57,35 @@ internal class PatchClasses internal constructor(
         }
     }
 
-    /**
-     * @return All strings found anywhere in all class methods.
-     */
-    private fun ClassDef.findMethodStrings(): List<String>? {
-        var list : MutableList<String>? = null
+    private data class ClassIndexValues(
+        val strings: MutableSet<String> = HashSet(),
+        val referencedTypeHashes: MutableSet<Int> = HashSet(),
+        val literalValues: MutableSet<Long> = HashSet(),
+    )
 
+    /** Collect string, type-reference, and literal values in one traversal. */
+    private fun ClassDef.findIndexValues(): ClassIndexValues {
+        val values = ClassIndexValues()
         methods.forEach { method ->
-            // Add strings contained in the method as the key.
             method.instructionsOrNull?.forEach { instruction ->
-                val opcode = instruction.opcode
-                if (opcode != Opcode.CONST_STRING && opcode != Opcode.CONST_STRING_JUMBO) {
-                    return@forEach
+                if (instruction is WideLiteralInstruction) {
+                    values.literalValues += instruction.wideLiteral
                 }
-
-                val string = ((instruction as ReferenceInstruction).reference as StringReference).string
-
-                if (list == null) {
-                    list = mutableListOf()
+                val reference = (instruction as? ReferenceInstruction)?.reference ?: return@forEach
+                when (reference) {
+                    is StringReference -> if (
+                        instruction.opcode == Opcode.CONST_STRING ||
+                        instruction.opcode == Opcode.CONST_STRING_JUMBO
+                    ) {
+                        values.strings += reference.string
+                    }
+                    is MethodReference -> values.referencedTypeHashes += reference.definingClass.hashCode()
+                    is FieldReference -> values.referencedTypeHashes += reference.definingClass.hashCode()
+                    is TypeReference -> values.referencedTypeHashes += reference.type.hashCode()
                 }
-                list.add(string)
             }
         }
-
-        return list
+        return values
     }
 
     /**
@@ -108,6 +123,10 @@ internal class PatchClasses internal constructor(
     internal fun closeStringMap() {
         stringMap = null
         allClassesWithStrings = null
+        classMap.values.forEach { wrapper ->
+            wrapper.referencedTypeHashes = null
+            wrapper.literalValues = null
+        }
     }
 
     internal fun addClass(classDef: ClassDef) {
@@ -119,29 +138,37 @@ internal class PatchClasses internal constructor(
             return stringMap!!
         }
 
+        return buildInstructionIndexes()
+    }
+
+    private fun buildInstructionIndexes(): Map<String, List<ClassDefWrapper>> {
         // Default 0.75f load factor works well and a lower value does not improve patching time.
-        val map = HashMap<String, MutableList<ClassDefWrapper>>()
+        val strings = HashMap<String, MutableList<ClassDefWrapper>>()
         val classesWithStrings = mutableListOf<ClassDefWrapper>()
 
         classMap.values.forEach { wrapper ->
-            val methodStrings = wrapper.classDef.findMethodStrings()
-            if (methodStrings != null) {
-                methodStrings.forEach { stringLiteral ->
-                    val list = map.getOrPut(stringLiteral) {
-                        ArrayList(1)
-                    }
-                    if (!list.contains(wrapper)) {
-                        list += wrapper
-                    }
+            val values = wrapper.classDef.findIndexValues()
+            if (values.strings.isNotEmpty()) {
+                values.strings.forEach { stringLiteral ->
+                    strings.getOrPut(stringLiteral) { ArrayList(1) } += wrapper
                 }
-
                 classesWithStrings += wrapper
+            }
+            wrapper.referencedTypeHashes = if (values.referencedTypeHashes.isEmpty()) {
+                EMPTY_TYPE_HASHES
+            } else {
+                values.referencedTypeHashes.sorted().toIntArray()
+            }
+            wrapper.literalValues = if (values.literalValues.isEmpty()) {
+                EMPTY_LITERAL_VALUES
+            } else {
+                values.literalValues.sorted().toLongArray()
             }
         }
 
-        stringMap = map
+        stringMap = strings
         allClassesWithStrings = classesWithStrings
-        return map
+        return strings
     }
 
     internal fun getClassesFromOpcodeStringLiteral(stringLiteral: String): List<ClassDefWrapper>? {
@@ -151,6 +178,25 @@ internal class PatchClasses internal constructor(
     internal fun getAllClassesWithStrings(): List<ClassDefWrapper> {
         getClassesByStringMap() // Load string map if needed.
         return allClassesWithStrings!!
+    }
+
+    internal fun getClassesReferencingType(type: String): List<ClassDefWrapper>? {
+        getClassesByStringMap() // Both instruction indexes are built in the same traversal.
+        val typeHash = type.hashCode()
+        return classMap.values.filter { wrapper ->
+            val hashes = wrapper.referencedTypeHashes
+            // Mutable and newly added classes may have changed since indexing.
+            hashes == null || wrapper.classDef is MutableClass || hashes.binarySearch(typeHash) >= 0
+        }.ifEmpty { null }
+    }
+
+    internal fun getClassesContainingLiteral(literal: Long): List<ClassDefWrapper>? {
+        getClassesByStringMap() // All instruction indexes are built in the same traversal.
+        return classMap.values.filter { wrapper ->
+            val values = wrapper.literalValues
+            // Mutable and newly added classes may have changed since indexing.
+            values == null || wrapper.classDef is MutableClass || values.binarySearch(literal) >= 0
+        }.ifEmpty { null }
     }
 
     /**
@@ -193,6 +239,11 @@ internal class PatchClasses internal constructor(
      */
     fun classBy(predicate: (ClassDef) -> Boolean) = classByOrNull(predicate)
         ?: throw PatchException("Could not find any class match")
+
+    private companion object {
+        private val EMPTY_TYPE_HASHES = IntArray(0)
+        private val EMPTY_LITERAL_VALUES = LongArray(0)
+    }
 
     /**
      * Find a class with a predicate.

--- a/src/main/kotlin/app/morphe/patcher/util/PatchClasses.kt
+++ b/src/main/kotlin/app/morphe/patcher/util/PatchClasses.kt
@@ -19,7 +19,6 @@ import com.android.tools.smali.dexlib2.iface.reference.FieldReference
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.iface.reference.StringReference
 import com.android.tools.smali.dexlib2.iface.reference.TypeReference
-import java.util.LinkedList
 
 /**
  * All classes for the target app and any extension classes.
@@ -117,10 +116,10 @@ internal class PatchClasses internal constructor(
 
     internal fun close() {
         classMap.clear()
-        closeStringMap()
+        closeReferenceMap()
     }
 
-    internal fun closeStringMap() {
+    internal fun closeReferenceMap() {
         stringMap = null
         allClassesWithStrings = null
         classMap.values.forEach { wrapper ->
@@ -133,7 +132,7 @@ internal class PatchClasses internal constructor(
         classMap[classDef.type] = ClassDefWrapper(classDef)
     }
 
-    internal fun getClassesByStringMap(): Map<String, List<ClassDefWrapper>> {
+    internal fun getClassesByReferenceMap(): Map<String, List<ClassDefWrapper>> {
         if (stringMap != null) {
             return stringMap!!
         }
@@ -172,16 +171,16 @@ internal class PatchClasses internal constructor(
     }
 
     internal fun getClassesFromOpcodeStringLiteral(stringLiteral: String): List<ClassDefWrapper>? {
-        return getClassesByStringMap()[stringLiteral]
+        return getClassesByReferenceMap()[stringLiteral]
     }
 
     internal fun getAllClassesWithStrings(): List<ClassDefWrapper> {
-        getClassesByStringMap() // Load string map if needed.
+        getClassesByReferenceMap() // Load string map if needed.
         return allClassesWithStrings!!
     }
 
     internal fun getClassesReferencingType(type: String): List<ClassDefWrapper>? {
-        getClassesByStringMap() // Both instruction indexes are built in the same traversal.
+        getClassesByReferenceMap() // Load reference map if needed.
         val typeHash = type.hashCode()
         return classMap.values.filter { wrapper ->
             val hashes = wrapper.referencedTypeHashes
@@ -191,7 +190,7 @@ internal class PatchClasses internal constructor(
     }
 
     internal fun getClassesContainingLiteral(literal: Long): List<ClassDefWrapper>? {
-        getClassesByStringMap() // All instruction indexes are built in the same traversal.
+        getClassesByReferenceMap() // Load reference map if needed.
         return classMap.values.filter { wrapper ->
             val values = wrapper.literalValues
             // Mutable and newly added classes may have changed since indexing.

--- a/src/test/kotlin/app/morphe/patcher/PatcherTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/PatcherTest.kt
@@ -55,6 +55,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 internal object PatcherTest {
@@ -496,6 +497,29 @@ internal object PatcherTest {
         )
 
         with(patcher.context.bytecodeContext) {
+            val cachedLiteralFingerprint = Fingerprint(
+                returnType = "Ljava/lang/String;",
+                filters = listOf(literal(0)),
+            )
+            cachedLiteralFingerprint.match(patchClasses.classBy("Lclass2;"))
+            assertEquals(
+                listOf("Lclass1;", "Lclass2;", "Lclass3;", "Lclass4;", "Lclass5;"),
+                cachedLiteralFingerprint.matchAll().map { it.originalClassDef.type },
+                "matchAll must start a new search instead of consuming a cached single match",
+            )
+
+            assertNull(
+                Fingerprint(filters = listOf(literal(1))).matchAllOrNull(),
+                "An empty literal candidate set must produce no match",
+            )
+            assertEquals(
+                listOf("Lclass1;", "Lclass2;", "Lclass3;", "Lclass4;", "Lclass5;"),
+                Fingerprint(
+                    filters = listOf(anyInstruction(literal(1), literal(0))),
+                ).matchAll().map { it.originalClassDef.type },
+                "AnyInstruction candidate sets must be safely unioned",
+            )
+
             class ProxyFilterCounter(val filter: InstructionFilter) : InstructionFilter {
                 var matchesCallCount = 0
 

--- a/src/test/kotlin/app/morphe/patcher/PatcherTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/PatcherTest.kt
@@ -43,6 +43,8 @@ import io.mockk.verify
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.api.assertAll
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -334,6 +336,42 @@ internal object PatcherTest {
         }
     }
 
+    @ParameterizedTest
+    @CsvSource(
+        "custom,false", "custom,true", "any,false", "any,true",
+        "nested-any,false", "nested-any,true", "bundled,false", "bundled,true",
+    )
+    fun `instruction indexes only filter bundled non-union fingerprints`(kind: String, matchAll: Boolean) {
+        val method = ImmutableMethod(
+            "Lcandidate;", "value", emptyList(), "V", AccessFlags.PUBLIC.value,
+            null, null, MutableMethodImplementation(1),
+        ).toMutable().apply {
+            addInstructions(0, "const/4 v0, 0x0\nreturn-void")
+        }
+        val classDef = ImmutableClassDef(
+            "Lcandidate;", 0, null, null, null, null, null, listOf(method),
+        )
+        every { patcher.context.bytecodeContext.patchClasses } returns PatchClasses(setOf(classDef))
+
+        val firstFilter = when (kind) {
+            "custom" -> InstructionFilter { _, _ -> true }
+            "any" -> anyInstruction(literal(0))
+            "nested-any" -> anyInstruction(anyInstruction(literal(0)))
+            else -> literal(0)
+        }
+        var visitedMethods = 0
+        val fingerprint = Fingerprint(
+            filters = listOf(firstFilter, literal(1)),
+            custom = { _, _ -> visitedMethods++; true },
+        )
+
+        with(patcher.context.bytecodeContext) {
+            if (matchAll) assertNull(fingerprint.matchAllOrNull())
+            else assertNull(fingerprint.matchOrNull())
+        }
+        assertEquals(if (kind == "bundled") 0 else 1, visitedMethods)
+    }
+
     @Test
     fun `fingerprint matchAll`() {
         val class1 = ImmutableClassDef(
@@ -517,7 +555,7 @@ internal object PatcherTest {
                 Fingerprint(
                     filters = listOf(anyInstruction(literal(1), literal(0))),
                 ).matchAll().map { it.originalClassDef.type },
-                "AnyInstruction candidate sets must be safely unioned",
+                "AnyInstruction must match through the full scan",
             )
 
             class ProxyFilterCounter(val filter: InstructionFilter) : InstructionFilter {

--- a/src/test/kotlin/app/morphe/patcher/apk/ApkUtilsTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/apk/ApkUtilsTest.kt
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patcher
+ */
+
+package app.morphe.patcher.apk
+
+import app.morphe.patcher.PatcherResult
+import app.morphe.patcher.apk.ApkUtils.applyTo
+import org.junit.jupiter.api.io.TempDir
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipFile
+import java.util.zip.ZipOutputStream
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+internal class ApkUtilsTest {
+    @TempDir
+    lateinit var temporaryDirectory: File
+
+    @Test
+    fun `compiled resource APK is used directly as the output base`() {
+        val targetApk = temporaryDirectory.resolve("target.apk").also { apk ->
+            writeZip(
+                apk,
+                mapOf(
+                    "assets/original-only.txt" to "original".toByteArray(),
+                    "res/raw/old.txt" to "old".toByteArray(),
+                    "classes.dex" to "original dex".toByteArray(),
+                ),
+            )
+        }
+        val resourcesApk = temporaryDirectory.resolve("resources.apk").also { apk ->
+            writeZip(
+                apk,
+                mapOf(
+                    "assets/resource-base-only.txt" to "resource base".toByteArray(),
+                    "assets/delete-me.txt" to "delete me".toByteArray(),
+                    "res/raw/new.txt" to "new".toByteArray(),
+                    "classes.dex" to "stale dex".toByteArray(),
+                    "classes99.dex" to "stale dex 99".toByteArray(),
+                ),
+            )
+        }
+        val otherResources = temporaryDirectory.resolve("other-resources").also { directory ->
+            directory.resolve("assets/raw-added.txt").apply {
+                parentFile.mkdirs()
+                writeText("raw resource")
+            }
+        }
+        val primaryDex = CloseTrackingInputStream("patched dex".toByteArray())
+        val secondaryDex = CloseTrackingInputStream("patched dex 2".toByteArray())
+        val result = PatcherResult(
+            linkedSetOf(
+                PatcherResult.PatchedDexFile("classes.dex", primaryDex),
+                PatcherResult.PatchedDexFile("classes2.dex", secondaryDex),
+            ),
+            PatcherResult.PatchedResources(
+                resourcesApk,
+                otherResources,
+                setOf("assets/raw-added.txt"),
+                setOf("assets/delete-me.txt"),
+            ),
+        )
+
+        result.applyTo(targetApk)
+
+        val entries = readZip(targetApk)
+        assertFalse("assets/original-only.txt" in entries)
+        assertFalse("res/raw/old.txt" in entries)
+        assertFalse("assets/delete-me.txt" in entries)
+        assertFalse("classes99.dex" in entries)
+        assertContentEquals("resource base".toByteArray(), entries["assets/resource-base-only.txt"])
+        assertContentEquals("new".toByteArray(), entries["res/raw/new.txt"])
+        assertContentEquals("raw resource".toByteArray(), entries["assets/raw-added.txt"])
+        assertContentEquals("patched dex".toByteArray(), entries["classes.dex"])
+        assertContentEquals("patched dex 2".toByteArray(), entries["classes2.dex"])
+        assertTrue(primaryDex.closed)
+        assertTrue(secondaryDex.closed)
+    }
+
+    @Test
+    fun `original APK remains the output base without a compiled resource APK`() {
+        val targetApk = temporaryDirectory.resolve("target.apk").also { apk ->
+            writeZip(
+                apk,
+                mapOf(
+                    "assets/original-only.txt" to "original".toByteArray(),
+                    "assets/delete-me.txt" to "delete me".toByteArray(),
+                    "classes.dex" to "original dex".toByteArray(),
+                    "classes2.dex" to "untouched dex".toByteArray(),
+                ),
+            )
+        }
+        val otherResources = temporaryDirectory.resolve("other-resources").also { directory ->
+            directory.resolve("assets/raw-added.txt").apply {
+                parentFile.mkdirs()
+                writeText("raw resource")
+            }
+        }
+        val primaryDex = CloseTrackingInputStream("patched dex".toByteArray())
+        val result = PatcherResult(
+            setOf(PatcherResult.PatchedDexFile("classes.dex", primaryDex)),
+            PatcherResult.PatchedResources(
+                null,
+                otherResources,
+                emptySet(),
+                setOf("assets/delete-me.txt"),
+            ),
+        )
+
+        result.applyTo(targetApk)
+
+        val entries = readZip(targetApk)
+        assertContentEquals("original".toByteArray(), entries["assets/original-only.txt"])
+        assertFalse("assets/delete-me.txt" in entries)
+        assertContentEquals("raw resource".toByteArray(), entries["assets/raw-added.txt"])
+        assertContentEquals("patched dex".toByteArray(), entries["classes.dex"])
+        assertContentEquals("untouched dex".toByteArray(), entries["classes2.dex"])
+        assertTrue(primaryDex.closed)
+    }
+
+    private fun writeZip(file: File, entries: Map<String, ByteArray>) {
+        ZipOutputStream(file.outputStream()).use { output ->
+            entries.forEach { (name, contents) ->
+                output.putNextEntry(ZipEntry(name))
+                output.write(contents)
+                output.closeEntry()
+            }
+        }
+    }
+
+    private fun readZip(file: File): Map<String, ByteArray> =
+        ZipFile(file).use { zip ->
+            zip.entries().asSequence().associate { entry ->
+                entry.name to zip.getInputStream(entry).use { it.readBytes() }
+            }
+        }
+
+    private class CloseTrackingInputStream(contents: ByteArray) : ByteArrayInputStream(contents) {
+        var closed = false
+            private set
+
+        override fun close() {
+            closed = true
+            super.close()
+        }
+    }
+}

--- a/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
@@ -13,12 +13,17 @@ import com.reandroid.apk.ApkModule
 import com.reandroid.archive.FileInputSource
 import com.reandroid.archive.io.ArchiveFileEntrySource
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import java.io.ByteArrayInputStream
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.nio.file.attribute.FileTime
+import java.util.concurrent.TimeUnit
 import java.util.zip.ZipFile
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -75,7 +80,7 @@ internal class ArsclibResourceCoderTest {
         val snapshot = coder.buildFileSnapshot()
         val entry = snapshot[file]!!
 
-        assertEquals(file.lastModified(), entry.lastModified)
+        assertEquals(Files.getLastModifiedTime(file.toPath()), entry.lastModified)
         assertEquals(file.length(), entry.size)
     }
 
@@ -145,10 +150,7 @@ internal class ArsclibResourceCoderTest {
 
         // Build a snapshot with the original size.
         val originalLastModified = file.lastModified()
-        val originalSize = file.length()
-        val snapshotEntry = ArsclibResourceCoder.FileSnapshot(originalLastModified, originalSize)
-
-        coder.fileSnapshotCache = mapOf(file to snapshotEntry)
+        coder.fileSnapshotCache = coder.buildFileSnapshot()
 
         // Change the content (and thus the size) but preserve the timestamp.
         file.writeText("this is a much longer string to change the file size")
@@ -176,6 +178,60 @@ internal class ArsclibResourceCoderTest {
 
         assertTrue(coder.modifiedResResources.isEmpty(), "No files should be in modifiedResResources")
         assertTrue(coder.modifiedBinaryResources.isEmpty(), "No files should be in modifiedBinaryResources")
+    }
+
+    @Test
+    fun `detectFileChanges identifies same-size replacement resource with preserved timestamp`() {
+        val pkgDir = setupPackageDir()
+        val file = pkgDir.resolve("res/values/strings.xml").apply {
+            parentFile.mkdirs()
+            writeText("before")
+        }
+        val originalLastModified = Files.getLastModifiedTime(file.toPath())
+        coder.fileSnapshotCache = coder.buildFileSnapshot()
+
+        Thread.sleep(10)
+        val replacement = file.resolveSibling("replacement.xml").apply { writeText("after!") }
+        Files.setLastModifiedTime(replacement.toPath(), originalLastModified)
+        Files.move(replacement.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING)
+
+        coder.detectFileChanges()
+
+        assertTrue(
+            coder.modifiedResResources.contains(file),
+            "A replacement file must not be hidden by identical size and timestamp metadata",
+        )
+    }
+
+    @Test
+    fun `detectFileChanges identifies high-resolution timestamp changes`() {
+        val file = coder.otherResourcesRootDirectory.resolve("assets/data.bin").apply {
+            parentFile.mkdirs()
+            writeBytes(byteArrayOf(1, 2, 3, 4))
+        }
+        val originalLastModified = FileTime.fromMillis(System.currentTimeMillis() - 1_000)
+        Files.setLastModifiedTime(file.toPath(), originalLastModified)
+        coder.fileSnapshotCache = coder.buildFileSnapshot()
+
+        file.writeBytes(byteArrayOf(4, 3, 2, 1))
+        val subMillisecondChange = FileTime.from(
+            originalLastModified.to(TimeUnit.NANOSECONDS) + 100_000,
+            TimeUnit.NANOSECONDS,
+        )
+        Files.setLastModifiedTime(
+            file.toPath(),
+            subMillisecondChange,
+        )
+        val storedLastModified = Files.getLastModifiedTime(file.toPath())
+        assumeTrue(storedLastModified != originalLastModified, "Filesystem does not retain sub-millisecond timestamps")
+        assumeTrue(storedLastModified.toMillis() == originalLastModified.toMillis())
+
+        coder.detectFileChanges()
+
+        assertTrue(
+            coder.modifiedBinaryResources.contains(file),
+            "Same-size changes must be detected from the filesystem timestamp",
+        )
     }
 
     // ==================== resource APK input reuse tests ====================

--- a/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
@@ -22,6 +22,7 @@ import java.io.ByteArrayInputStream
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
+import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.attribute.FileTime
 import java.util.concurrent.TimeUnit
 import java.util.zip.ZipFile
@@ -181,19 +182,25 @@ internal class ArsclibResourceCoderTest {
     }
 
     @Test
-    fun `detectFileChanges identifies same-size replacement resource with preserved timestamp`() {
+    fun `detectFileChanges identifies replacement when filesystem exposes changed metadata`() {
         val pkgDir = setupPackageDir()
         val file = pkgDir.resolve("res/values/strings.xml").apply {
             parentFile.mkdirs()
             writeText("before")
         }
-        val originalLastModified = Files.getLastModifiedTime(file.toPath())
+        val originalAttributes = Files.readAttributes(file.toPath(), BasicFileAttributes::class.java)
         coder.fileSnapshotCache = coder.buildFileSnapshot()
 
         Thread.sleep(10)
         val replacement = file.resolveSibling("replacement.xml").apply { writeText("after!") }
-        Files.setLastModifiedTime(replacement.toPath(), originalLastModified)
+        Files.setLastModifiedTime(replacement.toPath(), originalAttributes.lastModifiedTime())
         Files.move(replacement.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING)
+        val replacementAttributes = Files.readAttributes(file.toPath(), BasicFileAttributes::class.java)
+        assumeTrue(
+            replacementAttributes.creationTime() != originalAttributes.creationTime() ||
+                    replacementAttributes.fileKey() != originalAttributes.fileKey(),
+            "Filesystem does not expose distinguishable metadata for this replacement",
+        )
 
         coder.detectFileChanges()
 

--- a/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
@@ -9,6 +9,9 @@ import app.morphe.patcher.resource.CpuArchitecture
 import app.morphe.patcher.resource.PathMap
 import app.morphe.patcher.resource.ResourceMode
 import com.android.tools.build.apkzlib.zip.ZFile
+import com.reandroid.apk.ApkModule
+import com.reandroid.archive.FileInputSource
+import com.reandroid.archive.io.ArchiveFileEntrySource
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -16,8 +19,10 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import java.io.ByteArrayInputStream
 import java.io.File
+import java.util.zip.ZipFile
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 internal class ArsclibResourceCoderTest {
@@ -171,6 +176,104 @@ internal class ArsclibResourceCoderTest {
 
         assertTrue(coder.modifiedResResources.isEmpty(), "No files should be in modifiedResResources")
         assertTrue(coder.modifiedBinaryResources.isEmpty(), "No files should be in modifiedBinaryResources")
+    }
+
+    // ==================== resource APK input reuse tests ====================
+
+    @Test
+    fun `changedArchiveEntries maps decoded aliases back to original APK paths`() {
+        val packageDir = setupPackageDir()
+        val modifiedResource = packageDir.resolve("res/layout/readable.xml").apply {
+            parentFile.mkdirs()
+            writeText("<LinearLayout/>")
+        }
+        val modifiedBinary = coder.otherResourcesRootDirectory.resolve("assets/readable.bin").apply {
+            parentFile.mkdirs()
+            writeBytes(byteArrayOf(1, 2, 3))
+        }
+        coder.pathMap = PathMap(
+            """[
+                {"name":"res/a.xml","alias":"res/layout/readable.xml"},
+                {"name":"assets/b.bin","alias":"assets/readable.bin"}
+            ]""".trimIndent(),
+        )
+        coder.modifiedResResources += modifiedResource
+        coder.modifiedBinaryResources += modifiedBinary
+
+        val changedEntries = coder.changedArchiveEntries(packageRenamed = false)
+
+        assertEquals(
+            setOf("AndroidManifest.xml", "resources.arsc", "res/a.xml", "assets/b.bin"),
+            changedEntries,
+        )
+    }
+
+    @Test
+    fun `changedArchiveEntries rebuilds all compiled resources after package rename`() {
+        val packageDir = setupPackageDir()
+        packageDir.resolve("res/layout/unchanged.xml").apply {
+            parentFile.mkdirs()
+            writeText("<LinearLayout/>")
+        }
+        packageDir.resolve("res/drawable/unchanged.png").apply {
+            parentFile.mkdirs()
+            writeBytes(byteArrayOf(1, 2, 3))
+        }
+
+        val changedEntries = coder.changedArchiveEntries(packageRenamed = true)
+
+        assertTrue("res/layout/unchanged.xml" in changedEntries)
+        assertTrue("res/drawable/unchanged.png" in changedEntries)
+    }
+
+    @Test
+    fun `reuseUnchangedArchiveEntries preserves changed and new encoder inputs`(@TempDir tempDir: File) {
+        val originalApk = tempDir.resolve("original.apk")
+        ZFile.openReadWrite(originalApk).use { zip ->
+            zip.add("unchanged.bin", ByteArrayInputStream("original unchanged".toByteArray()))
+            zip.add("changed.bin", ByteArrayInputStream("original changed".toByteArray()))
+            zip.add("deleted.bin", ByteArrayInputStream("deleted".toByteArray()))
+        }
+
+        val encodedModule = ApkModule()
+        val unchangedFile = tempDir.resolve("unchanged.bin").apply { writeText("filesystem unchanged") }
+        val changedFile = tempDir.resolve("changed.bin").apply { writeText("patched changed") }
+        val newFile = tempDir.resolve("new.bin").apply { writeText("new") }
+        encodedModule.add(FileInputSource(unchangedFile, "unchanged.bin"))
+        encodedModule.add(FileInputSource(changedFile, "changed.bin"))
+        encodedModule.add(FileInputSource(newFile, "new.bin"))
+
+        val testCoder = ArsclibResourceCoder(tempDir.resolve("working").apply { mkdirs() }, originalApk)
+        ApkModule.loadApkFile(originalApk).use { originalModule ->
+            encodedModule.use { module ->
+                val reused = testCoder.reuseUnchangedArchiveEntries(
+                    originalModule,
+                    module,
+                    setOf("changed.bin"),
+                )
+
+                assertEquals(1, reused)
+                assertIs<ArchiveFileEntrySource>(module.zipEntryMap.getInputSource("unchanged.bin"))
+                assertIs<FileInputSource>(module.zipEntryMap.getInputSource("changed.bin"))
+                assertIs<FileInputSource>(module.zipEntryMap.getInputSource("new.bin"))
+                assertFalse(module.zipEntryMap.contains("deleted.bin"))
+
+                val outputApk = tempDir.resolve("output.apk")
+                module.writeApk(outputApk)
+                ZipFile(outputApk).use { zip ->
+                    assertEquals(
+                        "original unchanged",
+                        zip.getInputStream(zip.getEntry("unchanged.bin")).bufferedReader().readText(),
+                    )
+                    assertEquals(
+                        "patched changed",
+                        zip.getInputStream(zip.getEntry("changed.bin")).bufferedReader().readText(),
+                    )
+                    assertEquals("new", zip.getInputStream(zip.getEntry("new.bin")).bufferedReader().readText())
+                    assertEquals(null, zip.getEntry("deleted.bin"))
+                }
+            }
+        }
     }
 
     @Test

--- a/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
@@ -263,7 +263,7 @@ internal class ArsclibResourceCoderTest {
         coder.modifiedResResources += modifiedResource
         coder.modifiedBinaryResources += modifiedBinary
 
-        val changedEntries = coder.changedArchiveEntries(packageRenamed = false)
+        val changedEntries = coder.changedArchiveEntries()
 
         assertEquals(
             setOf("AndroidManifest.xml", "resources.arsc", "res/a.xml", "assets/b.bin"),
@@ -272,21 +272,22 @@ internal class ArsclibResourceCoderTest {
     }
 
     @Test
-    fun `changedArchiveEntries rebuilds all compiled resources after package rename`() {
+    fun `changedArchiveEntries rebuilds only resources reported as modified`() {
         val packageDir = setupPackageDir()
-        packageDir.resolve("res/layout/unchanged.xml").apply {
+        val unchanged = packageDir.resolve("res/layout/unchanged.xml").apply {
             parentFile.mkdirs()
             writeText("<LinearLayout/>")
         }
-        packageDir.resolve("res/drawable/unchanged.png").apply {
+        val changed = packageDir.resolve("res/drawable/changed.png").apply {
             parentFile.mkdirs()
             writeBytes(byteArrayOf(1, 2, 3))
         }
+        coder.modifiedResResources += changed
 
-        val changedEntries = coder.changedArchiveEntries(packageRenamed = true)
+        val changedEntries = coder.changedArchiveEntries()
 
-        assertTrue("res/layout/unchanged.xml" in changedEntries)
-        assertTrue("res/drawable/unchanged.png" in changedEntries)
+        assertFalse(unchanged.relativeTo(packageDir).invariantSeparatorsPath in changedEntries)
+        assertTrue("res/drawable/changed.png" in changedEntries)
     }
 
     @Test

--- a/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
@@ -427,7 +427,7 @@ internal class ArsclibResourceCoderTest {
             ApkModule().use { encoded ->
                 assertEquals(
                     2,
-                    testCoder.reuseUnchangedArchiveEntries(original, encoded, testCoder.changedArchiveEntries(false)),
+                    testCoder.reuseUnchangedArchiveEntries(original, encoded, testCoder.changedArchiveEntries()),
                 )
                 val output = tempDir.resolve("output.apk")
                 encoded.writeApk(output)

--- a/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
@@ -399,6 +399,52 @@ internal class ArsclibResourceCoderTest {
     }
 
     @Test
+    fun `reuseUnchangedArchiveEntries retains omitted root entries but not deleted files or dex`(
+        @TempDir tempDir: File,
+    ) {
+        val originalApk = tempDir.resolve("original.apk")
+        val entries = listOf(
+            "lib/arm64-v8a/keep.so", "lib/arm64-v8a/deleted.so", "lib/x86/stripped.so",
+            "assets/keep.txt", "assets/deleted.txt", "classes.dex", "res/raw/deleted.txt",
+        )
+        ZFile.openReadWrite(originalApk).use { zip ->
+            entries.forEach { zip.add(it, ByteArrayInputStream(it.toByteArray())) }
+        }
+        val testCoder = ArsclibResourceCoder(
+            tempDir.resolve("working").apply { mkdirs() }, originalApk, setOf(CpuArchitecture.ARM64_V8A),
+        )
+        val asset = testCoder.otherResourcesRootDirectory.resolve("assets/keep.txt").apply {
+            parentFile.mkdirs()
+            writeText("assets/keep.txt")
+        }
+        testCoder.fileSnapshotCache = testCoder.buildFileSnapshot()
+        asset.delete()
+        testCoder.deletedFiles += listOf("lib/arm64-v8a/deleted.so", "assets/deleted.txt")
+        testCoder.stripNativeLibraries()
+
+        ApkModule.loadApkFile(originalApk).use { original ->
+            ApkModule().use { encoded ->
+                assertEquals(
+                    2,
+                    testCoder.reuseUnchangedArchiveEntries(original, encoded, testCoder.changedArchiveEntries(false)),
+                )
+                val output = tempDir.resolve("output.apk")
+                encoded.writeApk(output)
+                ZipFile(output).use { zip ->
+                    assertEquals(
+                        setOf("lib/arm64-v8a/keep.so", "assets/keep.txt"),
+                        zip.entries().asSequence().map { it.name }.toSet(),
+                    )
+                    assertEquals(
+                        "assets/keep.txt",
+                        zip.getInputStream(zip.getEntry("assets/keep.txt")).bufferedReader().readText(),
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
     fun `detectFileChanges excludes public xml from tracking`() {
         val pkgDir = setupPackageDir()
         val resDir = pkgDir.resolve("res")

--- a/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
@@ -22,6 +22,7 @@ import java.io.ByteArrayInputStream
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
+import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.attribute.FileTime
 import java.util.concurrent.TimeUnit
 import java.util.zip.ZipFile
@@ -240,19 +241,25 @@ internal class ArsclibResourceCoderTest {
     }
 
     @Test
-    fun `detectFileChanges identifies same-size replacement resource with preserved timestamp`() {
+    fun `detectFileChanges identifies replacement when filesystem exposes changed metadata`() {
         val pkgDir = setupPackageDir()
         val file = pkgDir.resolve("res/values/strings.xml").apply {
             parentFile.mkdirs()
             writeText("before")
         }
-        val originalLastModified = Files.getLastModifiedTime(file.toPath())
+        val originalAttributes = Files.readAttributes(file.toPath(), BasicFileAttributes::class.java)
         coder.fileSnapshotCache = coder.buildFileSnapshot()
 
         Thread.sleep(10)
         val replacement = file.resolveSibling("replacement.xml").apply { writeText("after!") }
-        Files.setLastModifiedTime(replacement.toPath(), originalLastModified)
+        Files.setLastModifiedTime(replacement.toPath(), originalAttributes.lastModifiedTime())
         Files.move(replacement.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING)
+        val replacementAttributes = Files.readAttributes(file.toPath(), BasicFileAttributes::class.java)
+        assumeTrue(
+            replacementAttributes.creationTime() != originalAttributes.creationTime() ||
+                    replacementAttributes.fileKey() != originalAttributes.fileKey(),
+            "Filesystem does not expose distinguishable metadata for this replacement",
+        )
 
         coder.detectFileChanges()
 

--- a/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
@@ -9,6 +9,9 @@ import app.morphe.patcher.resource.CpuArchitecture
 import app.morphe.patcher.resource.PathMap
 import app.morphe.patcher.resource.ResourceMode
 import com.android.tools.build.apkzlib.zip.ZFile
+import com.reandroid.apk.ApkModule
+import com.reandroid.archive.FileInputSource
+import com.reandroid.archive.io.ArchiveFileEntrySource
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -16,8 +19,10 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import java.io.ByteArrayInputStream
 import java.io.File
+import java.util.zip.ZipFile
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 internal class ArsclibResourceCoderTest {
@@ -230,6 +235,104 @@ internal class ArsclibResourceCoderTest {
 
         assertTrue(coder.modifiedResResources.isEmpty(), "No files should be in modifiedResResources")
         assertTrue(coder.modifiedBinaryResources.isEmpty(), "No files should be in modifiedBinaryResources")
+    }
+
+    // ==================== resource APK input reuse tests ====================
+
+    @Test
+    fun `changedArchiveEntries maps decoded aliases back to original APK paths`() {
+        val packageDir = setupPackageDir()
+        val modifiedResource = packageDir.resolve("res/layout/readable.xml").apply {
+            parentFile.mkdirs()
+            writeText("<LinearLayout/>")
+        }
+        val modifiedBinary = coder.otherResourcesRootDirectory.resolve("assets/readable.bin").apply {
+            parentFile.mkdirs()
+            writeBytes(byteArrayOf(1, 2, 3))
+        }
+        coder.pathMap = PathMap(
+            """[
+                {"name":"res/a.xml","alias":"res/layout/readable.xml"},
+                {"name":"assets/b.bin","alias":"assets/readable.bin"}
+            ]""".trimIndent(),
+        )
+        coder.modifiedResResources += modifiedResource
+        coder.modifiedBinaryResources += modifiedBinary
+
+        val changedEntries = coder.changedArchiveEntries(packageRenamed = false)
+
+        assertEquals(
+            setOf("AndroidManifest.xml", "resources.arsc", "res/a.xml", "assets/b.bin"),
+            changedEntries,
+        )
+    }
+
+    @Test
+    fun `changedArchiveEntries rebuilds all compiled resources after package rename`() {
+        val packageDir = setupPackageDir()
+        packageDir.resolve("res/layout/unchanged.xml").apply {
+            parentFile.mkdirs()
+            writeText("<LinearLayout/>")
+        }
+        packageDir.resolve("res/drawable/unchanged.png").apply {
+            parentFile.mkdirs()
+            writeBytes(byteArrayOf(1, 2, 3))
+        }
+
+        val changedEntries = coder.changedArchiveEntries(packageRenamed = true)
+
+        assertTrue("res/layout/unchanged.xml" in changedEntries)
+        assertTrue("res/drawable/unchanged.png" in changedEntries)
+    }
+
+    @Test
+    fun `reuseUnchangedArchiveEntries preserves changed and new encoder inputs`(@TempDir tempDir: File) {
+        val originalApk = tempDir.resolve("original.apk")
+        ZFile.openReadWrite(originalApk).use { zip ->
+            zip.add("unchanged.bin", ByteArrayInputStream("original unchanged".toByteArray()))
+            zip.add("changed.bin", ByteArrayInputStream("original changed".toByteArray()))
+            zip.add("deleted.bin", ByteArrayInputStream("deleted".toByteArray()))
+        }
+
+        val encodedModule = ApkModule()
+        val unchangedFile = tempDir.resolve("unchanged.bin").apply { writeText("filesystem unchanged") }
+        val changedFile = tempDir.resolve("changed.bin").apply { writeText("patched changed") }
+        val newFile = tempDir.resolve("new.bin").apply { writeText("new") }
+        encodedModule.add(FileInputSource(unchangedFile, "unchanged.bin"))
+        encodedModule.add(FileInputSource(changedFile, "changed.bin"))
+        encodedModule.add(FileInputSource(newFile, "new.bin"))
+
+        val testCoder = ArsclibResourceCoder(tempDir.resolve("working").apply { mkdirs() }, originalApk)
+        ApkModule.loadApkFile(originalApk).use { originalModule ->
+            encodedModule.use { module ->
+                val reused = testCoder.reuseUnchangedArchiveEntries(
+                    originalModule,
+                    module,
+                    setOf("changed.bin"),
+                )
+
+                assertEquals(1, reused)
+                assertIs<ArchiveFileEntrySource>(module.zipEntryMap.getInputSource("unchanged.bin"))
+                assertIs<FileInputSource>(module.zipEntryMap.getInputSource("changed.bin"))
+                assertIs<FileInputSource>(module.zipEntryMap.getInputSource("new.bin"))
+                assertFalse(module.zipEntryMap.contains("deleted.bin"))
+
+                val outputApk = tempDir.resolve("output.apk")
+                module.writeApk(outputApk)
+                ZipFile(outputApk).use { zip ->
+                    assertEquals(
+                        "original unchanged",
+                        zip.getInputStream(zip.getEntry("unchanged.bin")).bufferedReader().readText(),
+                    )
+                    assertEquals(
+                        "patched changed",
+                        zip.getInputStream(zip.getEntry("changed.bin")).bufferedReader().readText(),
+                    )
+                    assertEquals("new", zip.getInputStream(zip.getEntry("new.bin")).bufferedReader().readText())
+                    assertEquals(null, zip.getEntry("deleted.bin"))
+                }
+            }
+        }
     }
 
     @Test

--- a/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
@@ -13,12 +13,17 @@ import com.reandroid.apk.ApkModule
 import com.reandroid.archive.FileInputSource
 import com.reandroid.archive.io.ArchiveFileEntrySource
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import java.io.ByteArrayInputStream
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.nio.file.attribute.FileTime
+import java.util.concurrent.TimeUnit
 import java.util.zip.ZipFile
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -134,7 +139,7 @@ internal class ArsclibResourceCoderTest {
         val snapshot = coder.buildFileSnapshot()
         val entry = snapshot[file.snapshotKey]!!
 
-        assertEquals(file.lastModified(), entry.lastModified)
+        assertEquals(Files.getLastModifiedTime(file.toPath()), entry.lastModified)
         assertEquals(file.length(), entry.size)
     }
 
@@ -204,10 +209,7 @@ internal class ArsclibResourceCoderTest {
 
         // Build a snapshot with the original size.
         val originalLastModified = file.lastModified()
-        val originalSize = file.length()
-        val snapshotEntry = ArsclibResourceCoder.FileSnapshot(originalLastModified, originalSize)
-
-        coder.fileSnapshotCache = mutableMapOf(file.snapshotKey to snapshotEntry)
+        coder.fileSnapshotCache = coder.buildFileSnapshot()
 
         // Change the content (and thus the size) but preserve the timestamp.
         file.writeText("this is a much longer string to change the file size")
@@ -235,6 +237,60 @@ internal class ArsclibResourceCoderTest {
 
         assertTrue(coder.modifiedResResources.isEmpty(), "No files should be in modifiedResResources")
         assertTrue(coder.modifiedBinaryResources.isEmpty(), "No files should be in modifiedBinaryResources")
+    }
+
+    @Test
+    fun `detectFileChanges identifies same-size replacement resource with preserved timestamp`() {
+        val pkgDir = setupPackageDir()
+        val file = pkgDir.resolve("res/values/strings.xml").apply {
+            parentFile.mkdirs()
+            writeText("before")
+        }
+        val originalLastModified = Files.getLastModifiedTime(file.toPath())
+        coder.fileSnapshotCache = coder.buildFileSnapshot()
+
+        Thread.sleep(10)
+        val replacement = file.resolveSibling("replacement.xml").apply { writeText("after!") }
+        Files.setLastModifiedTime(replacement.toPath(), originalLastModified)
+        Files.move(replacement.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING)
+
+        coder.detectFileChanges()
+
+        assertTrue(
+            coder.modifiedResResources.contains(file),
+            "A replacement file must not be hidden by identical size and timestamp metadata",
+        )
+    }
+
+    @Test
+    fun `detectFileChanges identifies high-resolution timestamp changes`() {
+        val file = coder.otherResourcesRootDirectory.resolve("assets/data.bin").apply {
+            parentFile.mkdirs()
+            writeBytes(byteArrayOf(1, 2, 3, 4))
+        }
+        val originalLastModified = FileTime.fromMillis(System.currentTimeMillis() - 1_000)
+        Files.setLastModifiedTime(file.toPath(), originalLastModified)
+        coder.fileSnapshotCache = coder.buildFileSnapshot()
+
+        file.writeBytes(byteArrayOf(4, 3, 2, 1))
+        val subMillisecondChange = FileTime.from(
+            originalLastModified.to(TimeUnit.NANOSECONDS) + 100_000,
+            TimeUnit.NANOSECONDS,
+        )
+        Files.setLastModifiedTime(
+            file.toPath(),
+            subMillisecondChange,
+        )
+        val storedLastModified = Files.getLastModifiedTime(file.toPath())
+        assumeTrue(storedLastModified != originalLastModified, "Filesystem does not retain sub-millisecond timestamps")
+        assumeTrue(storedLastModified.toMillis() == originalLastModified.toMillis())
+
+        coder.detectFileChanges()
+
+        assertTrue(
+            coder.modifiedBinaryResources.contains(file),
+            "Same-size changes must be detected from the filesystem timestamp",
+        )
     }
 
     // ==================== resource APK input reuse tests ====================

--- a/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
@@ -322,7 +322,7 @@ internal class ArsclibResourceCoderTest {
         coder.modifiedResResources += modifiedResource
         coder.modifiedBinaryResources += modifiedBinary
 
-        val changedEntries = coder.changedArchiveEntries(packageRenamed = false)
+        val changedEntries = coder.changedArchiveEntries()
 
         assertEquals(
             setOf("AndroidManifest.xml", "resources.arsc", "res/a.xml", "assets/b.bin"),
@@ -331,21 +331,22 @@ internal class ArsclibResourceCoderTest {
     }
 
     @Test
-    fun `changedArchiveEntries rebuilds all compiled resources after package rename`() {
+    fun `changedArchiveEntries rebuilds only resources reported as modified`() {
         val packageDir = setupPackageDir()
-        packageDir.resolve("res/layout/unchanged.xml").apply {
+        val unchanged = packageDir.resolve("res/layout/unchanged.xml").apply {
             parentFile.mkdirs()
             writeText("<LinearLayout/>")
         }
-        packageDir.resolve("res/drawable/unchanged.png").apply {
+        val changed = packageDir.resolve("res/drawable/changed.png").apply {
             parentFile.mkdirs()
             writeBytes(byteArrayOf(1, 2, 3))
         }
+        coder.modifiedResResources += changed
 
-        val changedEntries = coder.changedArchiveEntries(packageRenamed = true)
+        val changedEntries = coder.changedArchiveEntries()
 
-        assertTrue("res/layout/unchanged.xml" in changedEntries)
-        assertTrue("res/drawable/unchanged.png" in changedEntries)
+        assertFalse(unchanged.relativeTo(packageDir).invariantSeparatorsPath in changedEntries)
+        assertTrue("res/drawable/changed.png" in changedEntries)
     }
 
     @Test

--- a/src/test/kotlin/app/morphe/patcher/resource/processor/PackageRenamingProcessorTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/resource/processor/PackageRenamingProcessorTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
 import kotlin.test.assertContains
+import kotlin.test.assertContentEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -217,6 +218,30 @@ internal object PackageRenamingProcessorTest {
         )
     }
 
+    @Test
+    fun `process preserves byte exact XML when no package reference changes`() {
+        val xml = """<?xml version="1.0" encoding="UTF-8"?>
+            <resources>
+              <item name="untouched">  unusual whitespace  </item>
+            </resources>
+        """.trimIndent()
+
+        val result = processFile(xml)
+
+        assertContentEquals(xml.toByteArray(Charsets.UTF_8), result.bytes)
+        assertTrue(result.modifiedFiles.isEmpty())
+    }
+
+    @Test
+    fun `process reports only XML files containing renamed package references`() {
+        val result = processFile(
+            """<?xml version="1.0" encoding="UTF-8"?><resources><item>@com.original.app:id/value</item></resources>""",
+        )
+
+        assertTrue(result.modifiedFiles.single().name == "attrs.xml")
+        assertContains(result.text, "@com.new.app:id/value")
+    }
+
     // ==================== Helpers ====================
 
     private fun processFileAndRead(xmlContent: String): String {
@@ -224,6 +249,17 @@ internal object PackageRenamingProcessorTest {
     }
 
     private fun processFileAndReadBytes(xmlContent: String): Pair<String, ByteArray> {
+        val result = processFile(xmlContent)
+        return Pair(result.text, result.bytes)
+    }
+
+    private data class ProcessResult(
+        val text: String,
+        val bytes: ByteArray,
+        val modifiedFiles: Set<File>,
+    )
+
+    private fun processFile(xmlContent: String): ProcessResult {
         val originalPackageName = "com.original.app"
         val newPackageName = "com.new.app"
 
@@ -268,11 +304,11 @@ internal object PackageRenamingProcessorTest {
             newPackageName = newPackageName,
         )
 
-        processor.process()
+        val modifiedFiles = processor.process()
         publicXmlManager.close()
 
         val bytes = xmlFile.readBytes()
-        return Pair(String(bytes, Charsets.UTF_8), bytes)
+        return ProcessResult(String(bytes, Charsets.UTF_8), bytes, modifiedFiles)
     }
 
     private fun containsSubArray(haystack: ByteArray, needle: ByteArray): Boolean {

--- a/src/test/kotlin/app/morphe/patcher/resource/processor/StringsXmlSanitizeProcessorTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/resource/processor/StringsXmlSanitizeProcessorTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
 import kotlin.test.assertEquals
+import kotlin.test.assertSame
 
 internal object StringsXmlSanitizeProcessorTest {
 
@@ -52,6 +53,19 @@ internal object StringsXmlSanitizeProcessorTest {
     fun `sanitizeXmlText preserves standard XML whitespace characters`() {
         val input = "<resources>\t\n\r</resources>"
         assertEquals(input, sanitizeXmlText(input))
+    }
+
+    @Test
+    fun `sanitizeXmlText preserves supplementary Unicode characters without allocating`() {
+        val input = "<resources><string name=\"emoji\">\uD83D\uDE80</string></resources>"
+        assertSame(input, sanitizeXmlText(input))
+    }
+
+    @Test
+    fun `sanitizeXmlText removes an overflowing numeric character reference`() {
+        val input = "<resources><string name=\"bad\">&#999999999999999999999;</string></resources>"
+        val expected = "<resources><string name=\"bad\"></string></resources>"
+        assertEquals(expected, sanitizeXmlText(input))
     }
 
     // ==================== StringsXmlSanitizeProcessor round-trip tests ====================

--- a/src/test/kotlin/app/morphe/patcher/util/PatchClassesTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/util/PatchClassesTest.kt
@@ -10,9 +10,11 @@ import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.builder.MutableMethodImplementation
 import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction21c
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction31i
 import com.android.tools.smali.dexlib2.immutable.ImmutableClassDef
 import com.android.tools.smali.dexlib2.immutable.ImmutableMethod
 import com.android.tools.smali.dexlib2.immutable.reference.ImmutableStringReference
+import com.android.tools.smali.dexlib2.immutable.reference.ImmutableTypeReference
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -280,6 +282,125 @@ internal object PatchClassesTest {
         val classesWithStrings = patchClasses.getAllClassesWithStrings()
 
         assertEquals(3, classesWithStrings.size)  // Class1, Class2, Class3 (EmptyClass excluded)
+    }
+
+    @Test
+    fun `getClassesReferencingType uses instruction references`() {
+        val implementation = MutableMethodImplementation(1).apply {
+            addInstruction(
+                BuilderInstruction21c(
+                    Opcode.NEW_INSTANCE,
+                    0,
+                    ImmutableTypeReference("Lcom/test/Target;"),
+                ),
+            )
+        }
+        val method = ImmutableMethod(
+            "Lcom/test/Referrer;",
+            "create",
+            emptyList(),
+            "V",
+            AccessFlags.PUBLIC.value,
+            null,
+            null,
+            implementation,
+        )
+        val classes = PatchClasses(setOf(createClassDef("Lcom/test/Referrer;", listOf(method))))
+
+        assertEquals(
+            listOf("Lcom/test/Referrer;"),
+            classes.getClassesReferencingType("Lcom/test/Target;")?.map { it.classDef.type },
+        )
+        assertNull(classes.getClassesReferencingType("Lcom/test/Missing;"))
+    }
+
+    @Test
+    fun `getClassesContainingLiteral uses instruction literals`() {
+        val implementation = MutableMethodImplementation(1).apply {
+            addInstruction(BuilderInstruction31i(Opcode.CONST, 0, 0x7f123456))
+        }
+        val method = ImmutableMethod(
+            "Lcom/test/LiteralOwner;",
+            "value",
+            emptyList(),
+            "V",
+            AccessFlags.PUBLIC.value,
+            null,
+            null,
+            implementation,
+        )
+        val classes = PatchClasses(setOf(createClassDef("Lcom/test/LiteralOwner;", listOf(method))))
+
+        assertEquals(
+            listOf("Lcom/test/LiteralOwner;"),
+            classes.getClassesContainingLiteral(0x7f123456)?.map { it.classDef.type },
+        )
+        assertNull(classes.getClassesContainingLiteral(0x7f654321))
+    }
+
+    @Test
+    fun `instruction indexes retain newly added classes as candidates`() {
+        patchClasses.getClassesByStringMap()
+        val newClass = createClassDef("Lcom/test/NewAfterIndex;")
+
+        patchClasses.addClass(newClass)
+
+        assertEquals(
+            listOf("Lcom/test/NewAfterIndex;"),
+            patchClasses.getClassesContainingLiteral(123)?.map { it.classDef.type },
+        )
+        assertEquals(
+            listOf("Lcom/test/NewAfterIndex;"),
+            patchClasses.getClassesReferencingType("Lcom/test/AddedTarget;")?.map { it.classDef.type },
+        )
+    }
+
+    @Test
+    fun `instruction indexes retain mutable classes as candidates`() {
+        patchClasses.getClassesByStringMap()
+        patchClasses.classMap.getValue("Lcom/test/Class1;").getMutableClass()
+
+        assertEquals(
+            listOf("Lcom/test/Class1;"),
+            patchClasses.getClassesContainingLiteral(123)?.map { it.classDef.type },
+        )
+        assertEquals(
+            listOf("Lcom/test/Class1;"),
+            patchClasses.getClassesReferencingType("Lcom/test/ChangedTarget;")?.map { it.classDef.type },
+        )
+    }
+
+    @Test
+    fun `reference hash collisions remain safe false positives`() {
+        val indexedType = "LAa;"
+        val collidingType = "LBB;"
+        assertEquals(indexedType.hashCode(), collidingType.hashCode())
+
+        val implementation = MutableMethodImplementation(1).apply {
+            addInstruction(
+                BuilderInstruction21c(
+                    Opcode.NEW_INSTANCE,
+                    0,
+                    ImmutableTypeReference(indexedType),
+                ),
+            )
+        }
+        val method = ImmutableMethod(
+            "Lcom/test/CollisionOwner;",
+            "create",
+            emptyList(),
+            "V",
+            AccessFlags.PUBLIC.value,
+            null,
+            null,
+            implementation,
+        )
+        val classes = PatchClasses(setOf(createClassDef("Lcom/test/CollisionOwner;", listOf(method))))
+
+        assertEquals(
+            listOf("Lcom/test/CollisionOwner;"),
+            classes.getClassesReferencingType(collidingType)?.map { it.classDef.type },
+        )
     }
 
     // ==================== close tests ====================

--- a/src/test/kotlin/app/morphe/patcher/util/PatchClassesTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/util/PatchClassesTest.kt
@@ -253,7 +253,7 @@ internal object PatchClassesTest {
 
     @Test
     fun `getClassesByStringMap returns map of strings to classes`() {
-        val stringMap = patchClasses.getClassesByStringMap()
+        val stringMap = patchClasses.getClassesByReferenceMap()
 
         assertTrue(stringMap.isNotEmpty())
         assertTrue(stringMap.containsKey("hello"))
@@ -340,7 +340,7 @@ internal object PatchClassesTest {
 
     @Test
     fun `instruction indexes retain newly added classes as candidates`() {
-        patchClasses.getClassesByStringMap()
+        patchClasses.getClassesByReferenceMap()
         val newClass = createClassDef("Lcom/test/NewAfterIndex;")
 
         patchClasses.addClass(newClass)
@@ -357,7 +357,7 @@ internal object PatchClassesTest {
 
     @Test
     fun `instruction indexes retain mutable classes as candidates`() {
-        patchClasses.getClassesByStringMap()
+        patchClasses.getClassesByReferenceMap()
         patchClasses.classMap.getValue("Lcom/test/Class1;").getMutableClass()
 
         assertEquals(
@@ -415,12 +415,12 @@ internal object PatchClassesTest {
     }
 
     @Test
-    fun `closeStringMap clears only string map`() {
+    fun `getClassesByReferenceMap clears only reference map`() {
         // First build the string map
-        patchClasses.getClassesByStringMap()
+        patchClasses.getClassesByReferenceMap()
 
         // Close string map
-        patchClasses.closeStringMap()
+        patchClasses.closeReferenceMap()
 
         // Classes should still be accessible
         assertNotNull(patchClasses.classByOrNull("Lcom/test/Class1;"))


### PR DESCRIPTION
## Summary

- add compact per-class indexes for literal and referenced-type instruction filters
- use the indexes to skip classes that cannot match, then run the existing matcher on every candidate
- reuse unchanged APK entries in their original compressed form
- skip unnecessary XML and resource rewrites, and process independent string files concurrently
- make `matchAllOrNull` start a new search instead of reusing a cached single match

This PR is stacked on #169. Until #169 merges, GitHub's **Files changed** view includes both PRs.

## Implementation

The patcher builds the new instruction indexes during the existing string-index traversal. Each class stores sorted literal values and referenced-type hashes. Mutable and newly added classes remain candidates. A hash collision can add a candidate, but it cannot produce a false match because the normal fingerprint matcher still checks the class.

The resource coder tracks which files changed. It rebuilds those entries and reuses every other entry from the source APK. Reused entries keep their existing compressed data. The compiled resource APK also becomes the output base, which removes a second archive merge. XML processors no longer write files whose contents did not change.

## Results

I compared Morphe Desktop 1.13.0, which includes morphe-patcher 1.8.0, with commit `6af2690`. Both versions used the same Windows host, APKs, patches, Temurin 23.0.2, and `-Xmx8G`. Memory usage was measured with Java Flight Recorder (JFR). Each version had one warmup. Results are medians of three runs per version.

| App | Release time | Branch time | Speedup | Release peak heap | Branch peak heap |
|---|---:|---:|---:|---:|---:|
| YouTube | 270.332 s | 75.664 s | 3.57x | 1325.0 MiB | 1131.4 MiB |
| YouTube Music | 108.290 s | 43.526 s | 2.49x | 989.0 MiB | 780.8 MiB |
| Reddit | 154.988 s | 83.516 s | 1.86x | 1076.0 MiB | 1088.4 MiB |
| Instagram with Piko | 341.503 s | 78.862 s | 4.33x | 905.2 MiB | 849.6 MiB |
| TikTok | 671.641 s | 165.015 s | 4.07x | 2263.6 MiB | 1608.6 MiB |

Peak heap fell on four of the five apps. Reddit increased by 12.4 MiB.
## Correctness

- all 28 measured profiles applied every selected patch and produced an APK without failed patching steps
- APK signatures, ZIP alignment, and package metadata passed validation
- YouTube Music, Reddit, and repeated Piko outputs matched byte for byte outside signature metadata
- YouTube resources matched byte for byte; normalized DEX disassembly had no differences across 2,046,299 lines
- tests cover empty candidate sets, nested `AnyInstruction` filters, mutable and new classes, hash collisions, cached single-to-match-all behavior, selective archive reuse, and unchanged XML handling
- the full test suite and API compatibility checks pass; the public API is unchanged