### PR TITLE
feat: Add slider and range patch options

### DIFF
--- a/api/morphe-patcher.api
+++ b/api/morphe-patcher.api
@@ -685,6 +685,23 @@ public final class app/morphe/patcher/patch/FilesOption : app/morphe/patcher/pat
 	public final fun getFiles ()Ljava/util/List;
 }
 
+public final class app/morphe/patcher/patch/FloatRangeOption : app/morphe/patcher/patch/Option {
+	public fun <init> (Ljava/lang/String;FFLjava/util/List;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (Ljava/lang/String;FFLjava/util/List;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getMax ()F
+	public final fun getMin ()F
+	public final fun getRange ()Lkotlin/ranges/ClosedFloatingPointRange;
+	public final fun getStep ()Ljava/lang/Float;
+}
+
+public final class app/morphe/patcher/patch/FloatSliderOption : app/morphe/patcher/patch/Option {
+	public fun <init> (Ljava/lang/String;FFLjava/lang/Float;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (Ljava/lang/String;FFLjava/lang/Float;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getMax ()F
+	public final fun getMin ()F
+	public final fun getStep ()Ljava/lang/Float;
+}
+
 public final class app/morphe/patcher/patch/FolderOption : app/morphe/patcher/patch/StringOption {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -718,6 +735,23 @@ public final class app/morphe/patcher/patch/InstallerType : java/lang/Enum {
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lapp/morphe/patcher/patch/InstallerType;
 	public static fun values ()[Lapp/morphe/patcher/patch/InstallerType;
+}
+
+public final class app/morphe/patcher/patch/IntRangeOption : app/morphe/patcher/patch/Option {
+	public fun <init> (Ljava/lang/String;IILjava/util/List;ILjava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (Ljava/lang/String;IILjava/util/List;ILjava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getMax ()I
+	public final fun getMin ()I
+	public final fun getRange ()Lkotlin/ranges/IntRange;
+	public final fun getStep ()I
+}
+
+public final class app/morphe/patcher/patch/IntSliderOption : app/morphe/patcher/patch/Option {
+	public fun <init> (Ljava/lang/String;IILjava/lang/Integer;ILjava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (Ljava/lang/String;IILjava/lang/Integer;ILjava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getMax ()I
+	public final fun getMin ()I
+	public final fun getStep ()I
 }
 
 public class app/morphe/patcher/patch/Option {
@@ -1025,6 +1059,25 @@ public final class app/morphe/patcher/patch/ResourcePatchContext : app/morphe/pa
 	public final fun get (Ljava/lang/String;Z)Ljava/io/File;
 	public static synthetic fun get$default (Lapp/morphe/patcher/patch/ResourcePatchContext;Ljava/lang/String;ZILjava/lang/Object;)Ljava/io/File;
 	public final fun getPackageMetadata ()Lapp/morphe/patcher/PackageMetadata;
+}
+
+public final class app/morphe/patcher/patch/SliderOptionsKt {
+	public static final fun floatRangeOption (Lapp/morphe/patcher/patch/PatchBuilder;Ljava/lang/String;FFLjava/util/List;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;)Lapp/morphe/patcher/patch/FloatRangeOption;
+	public static final fun floatRangeOption (Ljava/lang/String;FFLjava/util/List;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;)Lapp/morphe/patcher/patch/FloatRangeOption;
+	public static synthetic fun floatRangeOption$default (Lapp/morphe/patcher/patch/PatchBuilder;Ljava/lang/String;FFLjava/util/List;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lapp/morphe/patcher/patch/FloatRangeOption;
+	public static synthetic fun floatRangeOption$default (Ljava/lang/String;FFLjava/util/List;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lapp/morphe/patcher/patch/FloatRangeOption;
+	public static final fun floatSliderOption (Lapp/morphe/patcher/patch/PatchBuilder;Ljava/lang/String;FFLjava/lang/Float;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;)Lapp/morphe/patcher/patch/FloatSliderOption;
+	public static final fun floatSliderOption (Ljava/lang/String;FFLjava/lang/Float;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;)Lapp/morphe/patcher/patch/FloatSliderOption;
+	public static synthetic fun floatSliderOption$default (Lapp/morphe/patcher/patch/PatchBuilder;Ljava/lang/String;FFLjava/lang/Float;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lapp/morphe/patcher/patch/FloatSliderOption;
+	public static synthetic fun floatSliderOption$default (Ljava/lang/String;FFLjava/lang/Float;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lapp/morphe/patcher/patch/FloatSliderOption;
+	public static final fun intRangeOption (Lapp/morphe/patcher/patch/PatchBuilder;Ljava/lang/String;IILjava/util/List;ILjava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;)Lapp/morphe/patcher/patch/IntRangeOption;
+	public static final fun intRangeOption (Ljava/lang/String;IILjava/util/List;ILjava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;)Lapp/morphe/patcher/patch/IntRangeOption;
+	public static synthetic fun intRangeOption$default (Lapp/morphe/patcher/patch/PatchBuilder;Ljava/lang/String;IILjava/util/List;ILjava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lapp/morphe/patcher/patch/IntRangeOption;
+	public static synthetic fun intRangeOption$default (Ljava/lang/String;IILjava/util/List;ILjava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lapp/morphe/patcher/patch/IntRangeOption;
+	public static final fun intSliderOption (Lapp/morphe/patcher/patch/PatchBuilder;Ljava/lang/String;IILjava/lang/Integer;ILjava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;)Lapp/morphe/patcher/patch/IntSliderOption;
+	public static final fun intSliderOption (Ljava/lang/String;IILjava/lang/Integer;ILjava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;)Lapp/morphe/patcher/patch/IntSliderOption;
+	public static synthetic fun intSliderOption$default (Lapp/morphe/patcher/patch/PatchBuilder;Ljava/lang/String;IILjava/lang/Integer;ILjava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lapp/morphe/patcher/patch/IntSliderOption;
+	public static synthetic fun intSliderOption$default (Ljava/lang/String;IILjava/lang/Integer;ILjava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lapp/morphe/patcher/patch/IntSliderOption;
 }
 
 public class app/morphe/patcher/patch/StringOption : app/morphe/patcher/patch/Option {

--- a/src/main/kotlin/app/morphe/patcher/patch/SliderOptions.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/SliderOptions.kt
@@ -1,0 +1,424 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patcher
+ */
+
+@file:Suppress("unused", "DEPRECATION")
+
+package app.morphe.patcher.patch
+
+import kotlin.math.abs
+import kotlin.math.roundToInt
+import kotlin.reflect.typeOf
+
+/**
+ * Largest deviation from an exact multiple of the step that is still accepted for
+ * floating point options, expressed in steps. Float arithmetic makes exact multiples
+ * unreachable, so a value one part in ten thousand off the scale still counts as on it.
+ */
+private const val FLOAT_STEP_TOLERANCE = 1e-4f
+
+/**
+ * Whether [value] lies within `[min, max]` and on the discrete scale defined by [step].
+ */
+private fun onScale(value: Int, min: Int, max: Int, step: Int) =
+    value in min..max && (value - min) % step == 0
+
+/**
+ * Whether [value] lies within `[min, max]` and on the discrete scale defined by [step].
+ * A null [step] means the slider is continuous, so only the bounds are checked.
+ */
+private fun onScale(value: Float, min: Float, max: Float, step: Float?): Boolean {
+    if (value.isNaN() || value < min || value > max) return false
+    if (step == null) return true
+
+    val steps = (value - min) / step
+    return abs(steps - steps.roundToInt()) <= FLOAT_STEP_TOLERANCE
+}
+
+/**
+ * Rejects a bound declaration that no value could ever satisfy. Patch authors get the
+ * error while their bundle is loading instead of when a value is first read.
+ */
+private fun requireValidBounds(min: Number, max: Number, step: Number?) {
+    require(min.toDouble() < max.toDouble()) { "min ($min) must be less than max ($max)" }
+    if (step != null) require(step.toDouble() > 0.0) { "step ($step) must be positive" }
+}
+
+/**
+ * Rejects a discrete scale whose upper bound cannot be reached from the lower one.
+ */
+private fun requireReachableMax(min: Int, max: Int, step: Int) =
+    require((max - min) % step == 0) {
+        "max ($max) must be reachable from min ($min) in steps of $step"
+    }
+
+/**
+ * Rejects a default that the option would reject as a value.
+ */
+private fun requireValidDefault(default: Int?, min: Int, max: Int, step: Int) =
+    require(default == null || onScale(default, min, max, step)) {
+        "default ($default) must be within [$min, $max] and on the scale of $step"
+    }
+
+private fun requireValidDefault(default: Float?, min: Float, max: Float, step: Float?) =
+    require(default == null || onScale(default, min, max, step)) {
+        "default ($default) must be within [$min, $max]" + (step?.let { " and on the scale of $it" } ?: "")
+    }
+
+/**
+ * Rejects a range default that is not an ordered pair of accepted values.
+ */
+private fun requireValidRangeDefault(default: List<Int>?, min: Int, max: Int, step: Int) {
+    require(default == null || default.size == 2) { "default must hold exactly two values" }
+    if (default == null) return
+    require(default[0] <= default[1]) { "default start (${default[0]}) must not exceed its end (${default[1]})" }
+    default.forEach { requireValidDefault(it, min, max, step) }
+}
+
+private fun requireValidRangeDefault(default: List<Float>?, min: Float, max: Float, step: Float?) {
+    require(default == null || default.size == 2) { "default must hold exactly two values" }
+    if (default == null) return
+    require(default[0] <= default[1]) { "default start (${default[0]}) must not exceed its end (${default[1]})" }
+    default.forEach { requireValidDefault(it, min, max, step) }
+}
+
+/**
+ * The bound check of a slider option, composed with the [user] validator so that both run
+ * for every value. Declared outside the option classes because a superclass constructor
+ * argument cannot read properties of the instance being constructed.
+ */
+private fun intScaleValidator(
+    min: Int,
+    max: Int,
+    step: Int,
+    user: Option<Int>.(Int?) -> Boolean,
+): Option<Int>.(Int?) -> Boolean =
+    { value -> value == null || (onScale(value, min, max, step) && user(this, value)) }
+
+private fun floatScaleValidator(
+    min: Float,
+    max: Float,
+    step: Float?,
+    user: Option<Float>.(Float?) -> Boolean,
+): Option<Float>.(Float?) -> Boolean =
+    { value -> value == null || (onScale(value, min, max, step) && user(this, value)) }
+
+private fun intRangeValidator(
+    min: Int,
+    max: Int,
+    step: Int,
+    user: Option<List<Int>>.(List<Int>?) -> Boolean,
+): Option<List<Int>>.(List<Int>?) -> Boolean = { value ->
+    value == null || (
+            value.size == 2 &&
+                    value[0] <= value[1] &&
+                    value.all { onScale(it, min, max, step) } &&
+                    user(this, value)
+            )
+}
+
+private fun floatRangeValidator(
+    min: Float,
+    max: Float,
+    step: Float?,
+    user: Option<List<Float>>.(List<Float>?) -> Boolean,
+): Option<List<Float>>.(List<Float>?) -> Boolean = { value ->
+    value == null || (
+            value.size == 2 &&
+                    value[0] <= value[1] &&
+                    value.all { onScale(it, min, max, step) } &&
+                    user(this, value)
+            )
+}
+
+/**
+ * An [Option] whose [Int] value is constrained to `[min, max]`. Signals to editors that this
+ * option should be edited with a slider rather than a numeric text field.
+ *
+ * The stored value is a plain [Int], so consumers that treat the option as `Option<Int>` see
+ * and mutate the same value as with a raw [intOption].
+ *
+ * The bounds are enforced by the option itself and not only by the editor, so a value coming
+ * from a command line or a configuration file is rejected the same way.
+ *
+ * @property min The smallest accepted value, and the left end of the slider.
+ * @property max The largest accepted value, and the right end of the slider.
+ * @property step The distance between two adjacent positions on the slider.
+ */
+class IntSliderOption @PublishedApi internal constructor(
+    key: String,
+    val min: Int,
+    val max: Int,
+    default: Int? = null,
+    val step: Int = 1,
+    title: String? = null,
+    description: String? = null,
+    required: Boolean = false,
+    validator: Option<Int>.(Int?) -> Boolean = { true },
+) : Option<Int>(
+    key,
+    default,
+    null,
+    title,
+    description,
+    required,
+    typeOf<Int>(),
+    intScaleValidator(min, max, step, validator),
+) {
+    init {
+        requireValidBounds(min, max, step)
+        requireReachableMax(min, max, step)
+        requireValidDefault(default, min, max, step)
+    }
+}
+
+/**
+ * An [Option] whose [Float] value is constrained to `[min, max]`. Signals to editors that this
+ * option should be edited with a slider rather than a numeric text field.
+ *
+ * @property min The smallest accepted value, and the left end of the slider.
+ * @property max The largest accepted value, and the right end of the slider.
+ * @property step The distance between two adjacent positions on the slider,
+ *   or null for a continuous slider.
+ */
+class FloatSliderOption @PublishedApi internal constructor(
+    key: String,
+    val min: Float,
+    val max: Float,
+    default: Float? = null,
+    val step: Float? = null,
+    title: String? = null,
+    description: String? = null,
+    required: Boolean = false,
+    validator: Option<Float>.(Float?) -> Boolean = { true },
+) : Option<Float>(
+    key,
+    default,
+    null,
+    title,
+    description,
+    required,
+    typeOf<Float>(),
+    floatScaleValidator(min, max, step, validator),
+) {
+    init {
+        requireValidBounds(min, max, step)
+        requireValidDefault(default, min, max, step)
+    }
+}
+
+/**
+ * An [Option] holding a closed range of [Int]s within `[min, max]`. Signals to editors that
+ * this option should be edited with a range slider.
+ *
+ * The stored value is a `List<Int>` of exactly two elements, `[start, end]`, because that is
+ * what every consumer of an option value already understands. Use [range] to read it as an
+ * [IntRange].
+ *
+ * @property min The smallest accepted value, and the left end of the slider.
+ * @property max The largest accepted value, and the right end of the slider.
+ * @property step The distance between two adjacent positions on the slider.
+ */
+class IntRangeOption @PublishedApi internal constructor(
+    key: String,
+    val min: Int,
+    val max: Int,
+    default: List<Int>? = null,
+    val step: Int = 1,
+    title: String? = null,
+    description: String? = null,
+    required: Boolean = false,
+    validator: Option<List<Int>>.(List<Int>?) -> Boolean = { true },
+) : Option<List<Int>>(
+    key,
+    default,
+    null,
+    title,
+    description,
+    required,
+    typeOf<List<Int>>(),
+    intRangeValidator(min, max, step, validator),
+) {
+    /** The current value as an [IntRange], or null when unset. */
+    val range: IntRange? get() = value?.let { it[0]..it[1] }
+
+    init {
+        requireValidBounds(min, max, step)
+        requireReachableMax(min, max, step)
+        requireValidRangeDefault(default, min, max, step)
+    }
+}
+
+/**
+ * An [Option] holding a closed range of [Float]s within `[min, max]`. Signals to editors that
+ * this option should be edited with a range slider.
+ *
+ * The stored value is a `List<Float>` of exactly two elements, `[start, end]`. Use [range] to
+ * read it as a closed range.
+ *
+ * @property min The smallest accepted value, and the left end of the slider.
+ * @property max The largest accepted value, and the right end of the slider.
+ * @property step The distance between two adjacent positions on the slider,
+ *   or null for a continuous slider.
+ */
+class FloatRangeOption @PublishedApi internal constructor(
+    key: String,
+    val min: Float,
+    val max: Float,
+    default: List<Float>? = null,
+    val step: Float? = null,
+    title: String? = null,
+    description: String? = null,
+    required: Boolean = false,
+    validator: Option<List<Float>>.(List<Float>?) -> Boolean = { true },
+) : Option<List<Float>>(
+    key,
+    default,
+    null,
+    title,
+    description,
+    required,
+    typeOf<List<Float>>(),
+    floatRangeValidator(min, max, step, validator),
+) {
+    /** The current value as a closed range, or null when unset. */
+    val range: ClosedFloatingPointRange<Float>? get() = value?.let { it[0]..it[1] }
+
+    init {
+        requireValidBounds(min, max, step)
+        requireValidRangeDefault(default, min, max, step)
+    }
+}
+
+// region Builders
+
+/**
+ * Create a new [IntSliderOption].
+ */
+fun intSliderOption(
+    key: String,
+    min: Int,
+    max: Int,
+    default: Int? = null,
+    step: Int = 1,
+    title: String? = null,
+    description: String? = null,
+    required: Boolean = false,
+    validator: Option<Int>.(Int?) -> Boolean = { true },
+) = IntSliderOption(key, min, max, default, step, title, description, required, validator)
+
+/**
+ * Create a new [IntSliderOption] and add it to the current [PatchBuilder].
+ */
+fun PatchBuilder<*>.intSliderOption(
+    key: String,
+    min: Int,
+    max: Int,
+    default: Int? = null,
+    step: Int = 1,
+    title: String? = null,
+    description: String? = null,
+    required: Boolean = false,
+    validator: Option<Int>.(Int?) -> Boolean = { true },
+): IntSliderOption = app.morphe.patcher.patch.intSliderOption(
+    key, min, max, default, step, title, description, required, validator,
+).also { it() }
+
+/**
+ * Create a new [FloatSliderOption].
+ */
+fun floatSliderOption(
+    key: String,
+    min: Float,
+    max: Float,
+    default: Float? = null,
+    step: Float? = null,
+    title: String? = null,
+    description: String? = null,
+    required: Boolean = false,
+    validator: Option<Float>.(Float?) -> Boolean = { true },
+) = FloatSliderOption(key, min, max, default, step, title, description, required, validator)
+
+/**
+ * Create a new [FloatSliderOption] and add it to the current [PatchBuilder].
+ */
+fun PatchBuilder<*>.floatSliderOption(
+    key: String,
+    min: Float,
+    max: Float,
+    default: Float? = null,
+    step: Float? = null,
+    title: String? = null,
+    description: String? = null,
+    required: Boolean = false,
+    validator: Option<Float>.(Float?) -> Boolean = { true },
+): FloatSliderOption = app.morphe.patcher.patch.floatSliderOption(
+    key, min, max, default, step, title, description, required, validator,
+).also { it() }
+
+/**
+ * Create a new [IntRangeOption].
+ */
+fun intRangeOption(
+    key: String,
+    min: Int,
+    max: Int,
+    default: List<Int>? = null,
+    step: Int = 1,
+    title: String? = null,
+    description: String? = null,
+    required: Boolean = false,
+    validator: Option<List<Int>>.(List<Int>?) -> Boolean = { true },
+) = IntRangeOption(key, min, max, default, step, title, description, required, validator)
+
+/**
+ * Create a new [IntRangeOption] and add it to the current [PatchBuilder].
+ */
+fun PatchBuilder<*>.intRangeOption(
+    key: String,
+    min: Int,
+    max: Int,
+    default: List<Int>? = null,
+    step: Int = 1,
+    title: String? = null,
+    description: String? = null,
+    required: Boolean = false,
+    validator: Option<List<Int>>.(List<Int>?) -> Boolean = { true },
+): IntRangeOption = app.morphe.patcher.patch.intRangeOption(
+    key, min, max, default, step, title, description, required, validator,
+).also { it() }
+
+/**
+ * Create a new [FloatRangeOption].
+ */
+fun floatRangeOption(
+    key: String,
+    min: Float,
+    max: Float,
+    default: List<Float>? = null,
+    step: Float? = null,
+    title: String? = null,
+    description: String? = null,
+    required: Boolean = false,
+    validator: Option<List<Float>>.(List<Float>?) -> Boolean = { true },
+) = FloatRangeOption(key, min, max, default, step, title, description, required, validator)
+
+/**
+ * Create a new [FloatRangeOption] and add it to the current [PatchBuilder].
+ */
+fun PatchBuilder<*>.floatRangeOption(
+    key: String,
+    min: Float,
+    max: Float,
+    default: List<Float>? = null,
+    step: Float? = null,
+    title: String? = null,
+    description: String? = null,
+    required: Boolean = false,
+    validator: Option<List<Float>>.(List<Float>?) -> Boolean = { true },
+): FloatRangeOption = app.morphe.patcher.patch.floatRangeOption(
+    key, min, max, default, step, title, description, required, validator,
+).also { it() }
+
+// endregion

--- a/src/test/kotlin/app/morphe/patcher/patch/options/SliderOptionsTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/patch/options/SliderOptionsTest.kt
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patcher
+ */
+
+package app.morphe.patcher.patch.options
+
+import app.morphe.patcher.patch.FloatRangeOption
+import app.morphe.patcher.patch.FloatSliderOption
+import app.morphe.patcher.patch.IntRangeOption
+import app.morphe.patcher.patch.IntSliderOption
+import app.morphe.patcher.patch.Option
+import app.morphe.patcher.patch.OptionException
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.patch.floatRangeOption
+import app.morphe.patcher.patch.floatSliderOption
+import app.morphe.patcher.patch.intOption
+import app.morphe.patcher.patch.intRangeOption
+import app.morphe.patcher.patch.intSliderOption
+import kotlin.reflect.typeOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+internal object SliderOptionsTest {
+    private val sliderPatch = bytecodePatch(default = true) {
+        intSliderOption("volume", min = 0, max = 100, default = 50, step = 5)
+        floatSliderOption("speed", min = 0.5f, max = 2f, default = 1f)
+        intRangeOption("hours", min = 0, max = 24, default = listOf(8, 17))
+        floatRangeOption("opacity", min = 0f, max = 1f, default = listOf(0.2f, 0.8f), step = 0.1f)
+
+        // Legacy numeric option, must NOT be promoted to a slider
+        intOption("legacyNumber", default = 7)
+    }
+
+    @Test
+    fun `intSliderOption carries its bounds and keeps Int as the value type`() {
+        val option = sliderPatch.options["volume"]
+        assertIs<IntSliderOption>(option)
+        assertEquals(0, option.min)
+        assertEquals(100, option.max)
+        assertEquals(5, option.step)
+        assertEquals(50, option.default)
+        assertEquals(typeOf<Int>(), option.type)
+    }
+
+    @Test
+    fun `intSliderOption accepts values on the scale`() {
+        val option = sliderPatch.options["volume"] as IntSliderOption
+        option.reset()
+
+        sliderPatch.options["volume"] = 0
+        assertEquals(0, option.value)
+        sliderPatch.options["volume"] = 100
+        assertEquals(100, option.value)
+        sliderPatch.options["volume"] = 35
+        assertEquals(35, option.value)
+
+        option.reset()
+    }
+
+    @Test
+    fun `intSliderOption rejects values outside its bounds`() {
+        val option = sliderPatch.options["volume"] as IntSliderOption
+
+        assertFailsWith<OptionException.ValueValidationException> {
+            sliderPatch.options["volume"] = 101
+        }
+        assertFailsWith<OptionException.ValueValidationException> {
+            sliderPatch.options["volume"] = -5
+        }
+
+        option.reset()
+    }
+
+    @Test
+    fun `intSliderOption rejects values off the step scale`() {
+        val option = sliderPatch.options["volume"] as IntSliderOption
+
+        assertFailsWith<OptionException.ValueValidationException> {
+            sliderPatch.options["volume"] = 33
+        }
+
+        option.reset()
+    }
+
+    @Test
+    fun `an unset value is still allowed when the option is not required`() {
+        val option = sliderPatch.options["volume"] as IntSliderOption
+
+        sliderPatch.options["volume"] = null
+        assertNull(option.value)
+
+        option.reset()
+    }
+
+    @Test
+    fun `the declared validator runs on top of the bound check`() {
+        val option = intSliderOption("even", min = 0, max = 10, default = 0) { it == null || it % 4 == 0 }
+
+        option.value = 8
+        assertEquals(8, option.value)
+
+        // Within bounds, but rejected by the patch author's own validator
+        assertFailsWith<OptionException.ValueValidationException> { option.value = 5 }
+        // Rejected by the bound check before the author's validator is reached
+        assertFailsWith<OptionException.ValueValidationException> { option.value = 12 }
+    }
+
+    @Test
+    fun `floatSliderOption without a step is continuous within its bounds`() {
+        val option = sliderPatch.options["speed"] as FloatSliderOption
+        assertNull(option.step)
+
+        sliderPatch.options["speed"] = 1.37f
+        assertEquals(1.37f, option.value)
+
+        assertFailsWith<OptionException.ValueValidationException> {
+            sliderPatch.options["speed"] = 2.5f
+        }
+
+        option.reset()
+    }
+
+    @Test
+    fun `floatSliderOption with a step tolerates float arithmetic`() {
+        val option = floatSliderOption("gain", min = 0f, max = 1f, default = 0f, step = 0.1f)
+
+        // 0.7f is not an exact multiple of 0.1f in binary floating point
+        option.value = 0.7f
+        assertEquals(0.7f, option.value)
+
+        assertFailsWith<OptionException.ValueValidationException> { option.value = 0.75f }
+    }
+
+    @Test
+    fun `intRangeOption stores an ordered pair and exposes it as an IntRange`() {
+        val option = sliderPatch.options["hours"]
+        assertIs<IntRangeOption>(option)
+        assertEquals(typeOf<List<Int>>(), option.type)
+        assertEquals(8..17, option.range)
+
+        sliderPatch.options["hours"] = listOf(2, 4)
+        assertEquals(2..4, option.range)
+
+        option.reset()
+    }
+
+    @Test
+    fun `intRangeOption rejects a reversed, oversized or out of bounds pair`() {
+        val option = sliderPatch.options["hours"] as IntRangeOption
+
+        assertFailsWith<OptionException.ValueValidationException> {
+            sliderPatch.options["hours"] = listOf(17, 8)
+        }
+        assertFailsWith<OptionException.ValueValidationException> {
+            sliderPatch.options["hours"] = listOf(1, 2, 3)
+        }
+        assertFailsWith<OptionException.ValueValidationException> {
+            sliderPatch.options["hours"] = listOf(0, 25)
+        }
+
+        option.reset()
+    }
+
+    @Test
+    fun `floatRangeOption exposes its value as a closed range`() {
+        val option = sliderPatch.options["opacity"]
+        assertIs<FloatRangeOption>(option)
+        assertEquals(0.2f..0.8f, option.range)
+
+        option.reset()
+    }
+
+    @Test
+    fun `a legacy intOption is not promoted to a slider`() {
+        val option = sliderPatch.options["legacyNumber"]
+        assertTrue(option !is IntSliderOption, "intOption must not be promoted to IntSliderOption")
+        assertIs<Option<*>>(option)
+        assertEquals(typeOf<Int>(), option.type)
+    }
+
+    @Test
+    fun `standalone builders return the correct subclass`() {
+        assertIs<IntSliderOption>(intSliderOption("a", min = 0, max = 1))
+        assertIs<FloatSliderOption>(floatSliderOption("b", min = 0f, max = 1f))
+        assertIs<IntRangeOption>(intRangeOption("c", min = 0, max = 1))
+        assertIs<FloatRangeOption>(floatRangeOption("d", min = 0f, max = 1f))
+    }
+
+    @Test
+    fun `an impossible declaration fails while the patch is being built`() {
+        // min is not below max
+        assertFailsWith<IllegalArgumentException> { intSliderOption("a", min = 10, max = 10) }
+        // step is not positive
+        assertFailsWith<IllegalArgumentException> { intSliderOption("b", min = 0, max = 10, step = 0) }
+        // max is unreachable from min in whole steps
+        assertFailsWith<IllegalArgumentException> { intSliderOption("c", min = 0, max = 10, step = 3) }
+        // default is outside the bounds
+        assertFailsWith<IllegalArgumentException> { intSliderOption("d", min = 0, max = 10, default = 11) }
+        // default is off the step scale
+        assertFailsWith<IllegalArgumentException> { intSliderOption("e", min = 0, max = 10, default = 3, step = 5) }
+        // range default is not a pair
+        assertFailsWith<IllegalArgumentException> { intRangeOption("f", min = 0, max = 10, default = listOf(1)) }
+        // range default is reversed
+        assertFailsWith<IllegalArgumentException> { intRangeOption("g", min = 0, max = 10, default = listOf(5, 1)) }
+    }
+}


### PR DESCRIPTION
## Summary

Adds slider and range editing for numeric patch options, so patch authors can declare bounds users cannot leave, and users get an exact value instead of a free-form number field.

Four typed options are introduced in the patcher: `intSliderOption`, `floatSliderOption`, `intRangeOption` and `floatRangeOption`. They follow the existing typed option pattern (`FolderOption`, `ImageOption`, `ColorOption`): the subclass carries a UI hint, while the stored value stays a plain `Int`, `Float` or a two element list. Nothing in the storage, import/export or CLI paths needed changing.

The bounds are enforced by the option itself rather than by the editor, so a value coming from the CLI or an options file is rejected the same way as one picked in the manager. Impossible declarations (min above max, non-positive step, unreachable max, out of range default) fail while the bundle is loading.

## Compatibility

Backward compatible: bundles that use plain `intOption` keep rendering as a numeric field. Bundles built against the new patcher declare the required patcher version, so an older manager reports "update the manager" instead of a linkage error.