### PR TITLE
feat: Add patch context `fileWorkspace`

### DIFF
--- a/api/morphe-patcher.api
+++ b/api/morphe-patcher.api
@@ -293,12 +293,14 @@ public final class app/morphe/patcher/Patcher : java/io/Closeable {
 }
 
 public final class app/morphe/patcher/PatcherConfig {
-	public fun <init> (Ljava/io/File;Ljava/io/File;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Lapp/morphe/patcher/dex/BytecodeMode;Lapp/morphe/patcher/dex/DexVerifier;)V
-	public synthetic fun <init> (Ljava/io/File;Ljava/io/File;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Lapp/morphe/patcher/dex/BytecodeMode;Lapp/morphe/patcher/dex/DexVerifier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/io/File;Ljava/io/File;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Lapp/morphe/patcher/dex/BytecodeMode;Lapp/morphe/patcher/dex/DexVerifier;Ljava/io/File;)V
+	public synthetic fun <init> (Ljava/io/File;Ljava/io/File;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Lapp/morphe/patcher/dex/BytecodeMode;Lapp/morphe/patcher/dex/DexVerifier;Ljava/io/File;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getFileWorkspace ()Ljava/io/File;
 }
 
 public final class app/morphe/patcher/PatcherContext : java/io/Closeable {
 	public fun close ()V
+	public final fun getFileWorkspace ()Ljava/io/File;
 	public final fun getPackageMetadata ()Lapp/morphe/patcher/PackageMetadata;
 }
 
@@ -628,6 +630,7 @@ public final class app/morphe/patcher/patch/BytecodePatchContext : app/morphe/pa
 	public fun get ()Ljava/util/Set;
 	public final fun getAllClassesWithString (Ljava/lang/String;)Ljava/util/List;
 	public final fun getAllClassesWithStrings ()Ljava/util/List;
+	public fun getFileWorkspace ()Ljava/io/File;
 	public final fun getPackageMetadata ()Lapp/morphe/patcher/PackageMetadata;
 	public final fun mutableClassDefBy (Lcom/android/tools/smali/dexlib2/iface/ClassDef;)Lapp/morphe/patcher/util/proxy/mutableTypes/MutableClass;
 	public final fun mutableClassDefBy (Ljava/lang/String;)Lapp/morphe/patcher/util/proxy/mutableTypes/MutableClass;
@@ -944,6 +947,7 @@ public abstract class app/morphe/patcher/patch/PatchBuilder {
 }
 
 public abstract interface class app/morphe/patcher/patch/PatchContext : java/util/function/Supplier {
+	public abstract fun getFileWorkspace ()Ljava/io/File;
 }
 
 public final class app/morphe/patcher/patch/PatchException : java/lang/Exception {
@@ -1058,6 +1062,7 @@ public final class app/morphe/patcher/patch/ResourcePatchContext : app/morphe/pa
 	public synthetic fun get ()Ljava/lang/Object;
 	public final fun get (Ljava/lang/String;Z)Ljava/io/File;
 	public static synthetic fun get$default (Lapp/morphe/patcher/patch/ResourcePatchContext;Ljava/lang/String;ZILjava/lang/Object;)Ljava/io/File;
+	public fun getFileWorkspace ()Ljava/io/File;
 	public final fun getPackageMetadata ()Lapp/morphe/patcher/PackageMetadata;
 }
 

--- a/src/main/kotlin/app/morphe/patcher/PatcherConfig.kt
+++ b/src/main/kotlin/app/morphe/patcher/PatcherConfig.kt
@@ -25,6 +25,7 @@ import java.util.logging.Logger
  * @param frameworkFileDirectory A path to the directory to cache the framework file in.
  * @param useArsclib Whether to use Arsclib for resource decoding and compiling.
  * @param verifier The output verifier to use.
+ * @param fileWorkspacePath Temporary file workspace that patches may use.
  */
 class PatcherConfig(
     internal val apkFile: File,
@@ -35,8 +36,15 @@ class PatcherConfig(
     internal val keepArchitectures: Set<CpuArchitecture> = emptySet(),
     internal val useBytecodeMode: BytecodeMode = BytecodeMode.STRIP_FAST,
     internal val verifier: DexVerifier = NoOpDexVerifier,
+    private val fileWorkspacePath: File? = null,
 ) {
     private val logger = Logger.getLogger(PatcherConfig::class.java.name)
+
+    /**
+     * The path to the file workspace directory.
+     * This directory has write access and can be used for temporary files.
+     */
+    val fileWorkspace: File = fileWorkspacePath ?: temporaryFilesPath.resolve("workspace")
 
     init {
         if (!useArsclib) {

--- a/src/main/kotlin/app/morphe/patcher/PatcherContext.kt
+++ b/src/main/kotlin/app/morphe/patcher/PatcherContext.kt
@@ -36,6 +36,11 @@ class PatcherContext internal constructor(config: PatcherConfig): Closeable {
     internal val resourceContext = ResourcePatchContext(config)
 
     /**
+     * The path to the file workspace directory.
+     */
+    val fileWorkspace = config.fileWorkspace
+
+    /**
      * [PackageMetadata] of the supplied [PatcherConfig.apkFile].
      */
     val packageMetadata = resourceContext.packageMetadata

--- a/src/main/kotlin/app/morphe/patcher/patch/BytecodePatchContext.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/BytecodePatchContext.kt
@@ -41,6 +41,8 @@ class BytecodePatchContext internal constructor(private val config: PatcherConfi
     Closeable {
     private val logger = Logger.getLogger(this::class.java.name)
 
+    override val fileWorkspace = config.fileWorkspace
+
     /**
      * [Opcodes] of the supplied [PatcherConfig.apkFile].
      */

--- a/src/main/kotlin/app/morphe/patcher/patch/PatchContext.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/PatchContext.kt
@@ -8,10 +8,17 @@
 
 package app.morphe.patcher.patch
 
+import java.io.File
 import java.util.function.Supplier
 
 /**
  * A common interface for contexts such as [ResourcePatchContext] and [BytecodePatchContext].
  */
 
-sealed interface PatchContext<T> : Supplier<T>
+sealed interface PatchContext<T> : Supplier<T> {
+    /**
+     * The path to the file workspace directory.
+     * This directory has write access and can be used for temporary files.
+     */
+    val fileWorkspace: File
+}

--- a/src/main/kotlin/app/morphe/patcher/patch/ResourcePatchContext.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/ResourcePatchContext.kt
@@ -23,13 +23,13 @@ import java.util.logging.Logger
 
 /**
  * A context for patches containing the current state of resources.
- *
- * @param packageMetadata The [PackageMetadata] of the target apk.
  */
 class ResourcePatchContext internal constructor(
     private val config: PatcherConfig,
 ) : PatchContext<PatcherResult.PatchedResources>, Closeable {
     private val logger = Logger.getLogger(ResourcePatchContext::class.java.name)
+
+    override val fileWorkspace = config.fileWorkspace
 
     private val resourceCoder: ResourceCoder = ArsclibResourceCoder(config.apkFiles, config.apkFile, config.keepArchitectures)
 


### PR DESCRIPTION
Adds a dedicated temporary workspace folder that patches can use as a temporary file space.
