### PR TITLE
fix: Prevent STRIP_SAFE from crashing and stabilise its DEX file naming

### DIFF
--- a/src/main/kotlin/app/morphe/patcher/patch/BytecodePatchContext.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/BytecodePatchContext.kt
@@ -57,7 +57,7 @@ class BytecodePatchContext internal constructor(private val config: PatcherConfi
      * read and before the file is rewritten, renamed, or deleted, so the deterministic
      * unmapping releases any Windows file lock in time for those operations.
      */
-    private var originalDexMappings: MutableMap<File, MappedFile> = HashMap()
+    private var originalDexMappings: MutableMap<File, MappedFile> = LinkedHashMap()
 
     /**
      * Class descriptors that existed in the original APK (before any extensions or patches).
@@ -94,7 +94,10 @@ class BytecodePatchContext internal constructor(private val config: PatcherConfi
         classDescriptorsByEntry = readResult.classDescriptorsByEntry
         patchClasses = PatchClasses(readResult.dexFile.classes)
 
-        originalDexMappings = HashMap<File, MappedFile>(readResult.mappedFiles.size).apply {
+        // Insertion-ordered so iteration follows the original classes*.dex order; a plain
+        // HashMap iterates in File-hash order, which varies with the temporary directory
+        // path and makes STRIP_SAFE's output file naming nondeterministic.
+        originalDexMappings = LinkedHashMap<File, MappedFile>(readResult.mappedFiles.size).apply {
             readResult.mappedFiles.forEachIndexed { index, mappedFile ->
                 put(mappedFile.originalFile, mappedFile)
             }
@@ -414,7 +417,9 @@ class BytecodePatchContext internal constructor(private val config: PatcherConfi
         }
 
         // 2. For each original DEX file, either pass through or rebuild without modified classes.
-        originalDexMappings.keys.forEachIndexed { i, originalDex ->
+        // Iterate over a snapshot: releaseDexMapping() removes entries from originalDexMappings
+        // while this loop runs, which would otherwise throw ConcurrentModificationException.
+        originalDexMappings.keys.toList().forEachIndexed { i, originalDex ->
             val entryDescriptors = classDescriptorsByEntry[originalDex.name] ?: emptySet()
             val hasModifiedClasses = entryDescriptors.any { it in modifiedOriginalDescriptors }
 


### PR DESCRIPTION
### Description

Enabling `STRIP_SAFE` crashes the patcher before it can finish writing DEX files. `compileStripSafe`
iterates `originalDexMappings.keys` and calls `releaseDexMapping()` inside the loop, which removes
from the same map, so a `ConcurrentModificationException` is thrown as soon as the first original DEX
is rebuilt or passed through. The mode cannot complete on any input.

Separately, `originalDexMappings` was a plain `HashMap` keyed by `File`, so its iteration order — and
with it the `classes*.dex` naming `STRIP_SAFE` produces — depended on the temporary directory's path
hash and varied between runs. The file contents were already deterministic; only which name each got
moved.

Fixes #159.

### Changes

- Iterate over a snapshot (`keys.toList()`) in `compileStripSafe`, so removing mappings during the
  loop no longer throws.
- Back `originalDexMappings` with a `LinkedHashMap`, so iteration follows the original
  `classes*.dex` order and the output naming is deterministic.

### Validation

- Reproduced #159 against unmodified `dev`: `STRIP_SAFE` throws `ConcurrentModificationException` at
  `BytecodePatchContext.compileStripSafe` on the first rebuilt DEX, exactly as reported.
- With the fix, `STRIP_SAFE` runs to completion, and its output file→content mapping is identical
  across repeated runs from different temporary directories.
- `./gradlew test` and `compileKotlin` pass.

### Notes

These changes were developed and measured with AI assistance.
