### PR TITLE
perf: Reduce serial work in the DEX write phase

### DIFF
--- a/src/main/kotlin/app/morphe/patcher/dex/DexReadWrite.kt
+++ b/src/main/kotlin/app/morphe/patcher/dex/DexReadWrite.kt
@@ -206,16 +206,19 @@ internal object DexReadWrite {
         val segments = splitIntoMutableSegments(classDefs, numSegments)
         classDefs.clear()
 
-        val segmentResults = if (numSegments == 1) {
+        // Parallelize over the actual segment list: a desugar (j$) segment may exist in
+        // addition to the requested segments, and it can be written concurrently too.
+        val segmentResults = if (segments.size == 1) {
             logger?.info("Processing $numClasses classes (single threaded mode)")
 
             segments.mapIndexed { index, segment ->
                 processSegment(segment, opcodes, outputDir, index)
             }
         } else {
-            logger?.info("Processing $numClasses classes in parallel (${actualMaxThreads} threads)")
+            val parallelism = min(segments.size, actualMaxThreads)
+            logger?.info("Processing $numClasses classes in parallel ($parallelism threads)")
 
-            val dispatcher = Dispatchers.Default.limitedParallelism(numSegments)
+            val dispatcher = Dispatchers.Default.limitedParallelism(parallelism)
             runBlocking(dispatcher) {
                 segments.mapIndexed { segmentIndex, classQueue ->
                     async {

--- a/src/main/kotlin/app/morphe/patcher/dex/DexStripper.kt
+++ b/src/main/kotlin/app/morphe/patcher/dex/DexStripper.kt
@@ -112,7 +112,11 @@ internal object DexStripper {
         recomputeSignature(buf, fileSize)
         recomputeChecksum(buf, fileSize)
 
-        mappedFile.force()
+        // No mappedFile.force() (msync): the write-back to storage is left to the OS.
+        // The page cache keeps mapped writes coherent with subsequent reads and renames
+        // on all supported platforms, and durability against power loss is irrelevant
+        // for these temporary files. A synchronous flush here costs real time on
+        // device flash storage for no benefit.
 
         return indicesToRemove.size
     }

--- a/src/main/kotlin/app/morphe/patcher/patch/BytecodePatchContext.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/BytecodePatchContext.kt
@@ -25,10 +25,15 @@ import app.morphe.patcher.util.proxy.mutableTypes.MutableClass
 import com.android.tools.smali.dexlib2.Opcodes
 import com.android.tools.smali.dexlib2.iface.ClassDef
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
 import java.io.Closeable
 import java.io.File
 import java.io.InputStream
 import java.util.logging.Logger
+import kotlin.math.min
 
 /**
  * A context for patches containing the current state of the bytecode.
@@ -40,6 +45,14 @@ class BytecodePatchContext internal constructor(private val config: PatcherConfi
     PatchContext<Set<PatcherResult.PatchedDexFile>>,
     Closeable {
     private val logger = Logger.getLogger(this::class.java.name)
+
+    private companion object {
+        /**
+         * Upper bound on the number of original DEX files stripped concurrently
+         * by [compileStripFast]. Matches the bound used for parallel DEX writing.
+         */
+        private const val MAX_STRIP_THREADS = 4
+    }
 
     override val fileWorkspace = config.fileWorkspace
 
@@ -363,12 +376,40 @@ class BytecodePatchContext internal constructor(private val config: PatcherConfi
         }
 
         // 2. Strip modified class_def entries from original DEX files in-place.
+        // Each file is fully independent (its own memory mapping), so the files are
+        // stripped in parallel. Files that contain no modified classes are skipped
+        // entirely using the class-descriptor index built at decode time.
         if (modifiedOriginalDescriptors.isNotEmpty()) {
             logger.info("Stripping ${modifiedOriginalDescriptors.size} modified classes from original DEX files")
-            originalDexMappings.forEach { (originalDex, mappedFile) ->
-                val stripped = DexStripper.stripInPlace(mappedFile, modifiedOriginalDescriptors)
-                if (stripped > 0) {
-                    logger.fine { "Stripped $stripped class_def entries from ${originalDex.name}" }
+
+            val mappingsToStrip = originalDexMappings.entries.filter { (originalDex, _) ->
+                classDescriptorsByEntry[originalDex.name]
+                    ?.any { it in modifiedOriginalDescriptors }
+                    ?: true // Unknown entry: strip defensively.
+            }
+
+            if (mappingsToStrip.size <= 1) {
+                mappingsToStrip.forEach { (originalDex, mappedFile) ->
+                    val stripped = DexStripper.stripInPlace(mappedFile, modifiedOriginalDescriptors)
+                    if (stripped > 0) {
+                        logger.fine { "Stripped $stripped class_def entries from ${originalDex.name}" }
+                    }
+                }
+            } else {
+                val parallelism = min(
+                    mappingsToStrip.size,
+                    min(Runtime.getRuntime().availableProcessors(), MAX_STRIP_THREADS),
+                )
+                val dispatcher = Dispatchers.Default.limitedParallelism(parallelism)
+                runBlocking(dispatcher) {
+                    mappingsToStrip.map { (originalDex, mappedFile) ->
+                        async {
+                            val stripped = DexStripper.stripInPlace(mappedFile, modifiedOriginalDescriptors)
+                            if (stripped > 0) {
+                                logger.fine { "Stripped $stripped class_def entries from ${originalDex.name}" }
+                            }
+                        }
+                    }.awaitAll()
                 }
             }
         }


### PR DESCRIPTION
### Description

The DEX write phase (`BytecodePatchContext.get()`) does more serial work than it needs to. The
in-place strip of modified `class_def` entries runs one original DEX file at a time — each pass a
full `class_defs` scan, `class_data` compaction, and SHA-1/Adler32 recomputation — even though the
files are independent memory mappings. The multi-DEX writer decides sequential vs. parallel from the
requested segment count and so misses the extra `j$`/desugar segment. And each in-place strip ends
with a full `msync` of the rewritten file, whose durability is irrelevant for a temporary file.

None of these change the produced bytes; they remove redundant work and serialisation.

### Changes

- Strip up to four independent original DEX files concurrently, and skip files with no modified
  classes using the per-entry class-descriptor index built at decode time.
- Base the writer's parallel/sequential decision on the actual segment list, so the desugar segment
  overlaps the main segments instead of running after them. Partitioning is unchanged.
- Drop the `msync` after in-place stripping. The page cache keeps mapped writes coherent with the
  subsequent reads and renames on all supported platforms, and these files are temporary, so the
  synchronous flush only cost time on device flash.

### Validation

- Output DEX files are byte-identical (SHA-256) before and after, for both `STRIP_FAST` and `FULL`.
- On device (`STRIP_FAST`, the manager's default): a full YouTube patch produces output
  content-identical to unmodified `dev`, and the patched app installs, launches, and runs patched
  code with no `VerifyError`.
- `./gradlew test` and `compileKotlin` pass.

### Measurement

One illustrative run — not a promise; the effect depends on the device, the app, and how many DEX
files carry modified classes. On an emulator patching YouTube 21.04.223, the DEX write phase was the
part these changes act on; the strip step in particular fell substantially once it stopped running
serially and stopped flushing. Larger gains are expected on device flash, where the `msync` and the
serial SHA-1 recomputation cost the most.

> Stacked on #185. Until that merges, the diff here also shows its one commit; it drops out once #185 lands on `dev`.

### Notes

These changes were developed and measured with AI assistance.
