### PR TITLE
perf: Leave unchanged root entries in the input APK

### DIFF
--- a/src/main/kotlin/app/morphe/patcher/apk/ApkUtils.kt
+++ b/src/main/kotlin/app/morphe/patcher/apk/ApkUtils.kt
@@ -55,7 +55,13 @@ object ApkUtils {
      * 5. Write patched dex files.
      * 6. Realign the APK.
      *
-     * @param apkFile The file to apply the patched files to.
+     * [apkFile] must be a copy of the APK that was patched. The result is a set of changes
+     * against that APK rather than a self-contained APK: entries a patch did not touch, such as
+     * native libraries and assets, are expected to already be present in [apkFile] and are not
+     * carried in the result. Applying this to any other file silently produces an APK missing
+     * those entries.
+     *
+     * @param apkFile A copy of the patched APK, to apply the patched files to.
      */
     fun PatcherResult.applyTo(apkFile: File) {
         ZFile.openReadWrite(apkFile, zFileOptions).use { targetApkZFile ->

--- a/src/main/kotlin/app/morphe/patcher/resource/UncompressedFiles.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/UncompressedFiles.kt
@@ -23,6 +23,11 @@ import com.reandroid.json.JSONObject
 internal class UncompressedFiles(
     uncompressedFilesJson: String,
     private val pathMap: PathMap = PathMap.EMPTY,
+    /**
+     * Paths that must be stored uncompressed regardless of what the input APK declared,
+     * used when a patch changes `android:extractNativeLibs`.
+     */
+    private val additionalPaths: Set<String> = emptySet(),
 ) : AbstractSet<String>() {
 
     private val extensions: Set<String>
@@ -55,7 +60,7 @@ internal class UncompressedFiles(
      * matches are not counted here, as they represent rules rather than
      * concrete entries.
      */
-    override val size: Int get() = paths.size
+    override val size: Int get() = (paths + additionalPaths.map { sanitizePath(it) }).size
 
     /**
      * Returns `true` if [element] (or the original APK name it maps to via
@@ -65,6 +70,8 @@ internal class UncompressedFiles(
     override fun contains(element: String): Boolean {
         val normalized = sanitizePath(element)
         if (paths.contains(normalized)) return true
+        if (additionalPaths.isNotEmpty() &&
+            additionalPaths.any { sanitizePath(it) == normalized }) return true
 
         // The element may be an on-disk alias; resolve to original APK name.
         val originalName = pathMap.getOriginalName(normalized)
@@ -73,7 +80,9 @@ internal class UncompressedFiles(
         return matchesExtension(normalized)
     }
 
-    override fun iterator(): Iterator<String> = paths.iterator()
+    override fun iterator(): Iterator<String> =
+        if (additionalPaths.isEmpty()) paths.iterator()
+        else (paths + additionalPaths.map { sanitizePath(it) }).iterator()
 
     private fun matchesExtension(path: String): Boolean {
         if (extensions.isEmpty()) return false

--- a/src/main/kotlin/app/morphe/patcher/resource/UncompressedFiles.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/UncompressedFiles.kt
@@ -33,6 +33,11 @@ internal class UncompressedFiles(
     private val extensions: Set<String>
     private val paths: Set<String>
 
+    /** Sanitized once, since size, contains and iterator all consult it. */
+    private val sanitizedAdditionalPaths: Set<String> by lazy {
+        additionalPaths.mapTo(mutableSetOf()) { sanitizePath(it) }
+    }
+
     init {
         val json = JSONObject(uncompressedFilesJson)
 
@@ -60,7 +65,8 @@ internal class UncompressedFiles(
      * matches are not counted here, as they represent rules rather than
      * concrete entries.
      */
-    override val size: Int get() = (paths + additionalPaths.map { sanitizePath(it) }).size
+    override val size: Int get() = if (sanitizedAdditionalPaths.isEmpty()) paths.size
+        else (paths + sanitizedAdditionalPaths).size
 
     /**
      * Returns `true` if [element] (or the original APK name it maps to via
@@ -70,8 +76,7 @@ internal class UncompressedFiles(
     override fun contains(element: String): Boolean {
         val normalized = sanitizePath(element)
         if (paths.contains(normalized)) return true
-        if (additionalPaths.isNotEmpty() &&
-            additionalPaths.any { sanitizePath(it) == normalized }) return true
+        if (normalized in sanitizedAdditionalPaths) return true
 
         // The element may be an on-disk alias; resolve to original APK name.
         val originalName = pathMap.getOriginalName(normalized)
@@ -81,8 +86,8 @@ internal class UncompressedFiles(
     }
 
     override fun iterator(): Iterator<String> =
-        if (additionalPaths.isEmpty()) paths.iterator()
-        else (paths + additionalPaths.map { sanitizePath(it) }).iterator()
+        if (sanitizedAdditionalPaths.isEmpty()) paths.iterator()
+        else (paths + sanitizedAdditionalPaths).iterator()
 
     private fun matchesExtension(path: String): Boolean {
         if (extensions.isEmpty()) return false

--- a/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
@@ -94,7 +94,7 @@ internal class ArsclibResourceCoder(
      * Used to detect which files were added or modified between decoding and encoding.
      */
     internal data class FileSnapshot(val lastModified: Long, val size: Long)
-    internal var fileSnapshotCache: MutableMap<File, FileSnapshot> = mutableMapOf()
+    internal var fileSnapshotCache: MutableMap<String, FileSnapshot> = mutableMapOf()
 
     /**
      * Root entries (lib/, assets/, ...) are left in the input APK instead of being
@@ -102,10 +102,33 @@ internal class ArsclibResourceCoder(
      * APK, so every unchanged root entry is already present and correct in the target.
      * Only entries a patch actually asks for are extracted, by [getFile].
      */
-    private val lazilyExtractedRootFiles = mutableMapOf<File, Int>()
+    private val lazilyExtractedRootFiles = mutableMapOf<String, ExtractedRootFile>()
 
     /** Relocated root files, mapped to the archive entry name they must be written back as. */
-    private val relocatedRootFiles = mutableMapOf<File, String>()
+    private val relocatedRootFiles = mutableMapOf<String, String>()
+
+    /**
+     * Content of a root entry as extracted, for detecting whether a patch went on to change it.
+     * Length is compared alongside the hash, which is [java.util.Arrays.hashCode] over the bytes:
+     * fast and good enough to spot a patch's edit, but not a cryptographic digest.
+     */
+    internal data class ExtractedRootFile(val length: Long, val hash: Int)
+
+    /**
+     * Files are keyed by a canonical path string rather than by [File], whose equality is a plain
+     * path comparison and so misses when the same file is reached by a differently spelled path.
+     */
+    private fun pathKey(file: File) = file.absoluteFile.invariantSeparatorsPath
+
+    /**
+     * The working directory holds *alias* paths (readable, e.g. `res/drawable-mdpi/icon.png`)
+     * while the archive holds *original* entry names (often obfuscated, e.g. `res/-5N.png`).
+     * [PathMap.getAlias] maps archive name to on-disk alias; [PathMap.getOriginalName] maps back.
+     * Everything that crosses that boundary goes through these two helpers.
+     */
+    private fun archiveNameOf(aliasedPath: String) = pathMap.getOriginalName(aliasedPath) ?: aliasedPath
+
+    private fun aliasOf(archiveName: String) = pathMap.getAlias(archiveName) ?: archiveName
 
     /**
      * Native library entries removed by [stripNativeLibraries], as in-APK paths.
@@ -120,13 +143,12 @@ internal class ArsclibResourceCoder(
     /**
      * Recursively scan the working directory and build a map of file paths to their metadata.
      */
-    internal fun buildFileSnapshot(): MutableMap<File, FileSnapshot> {
-        val snapshot = mutableMapOf<File, FileSnapshot>()
-        workingDir.resolve("resources").walkTopDown().filter { it.isFile }.forEach { file ->
-            snapshot[file] = FileSnapshot(file.lastModified(), file.length())
-        }
-        workingDir.resolve("root").walkTopDown().filter { it.isFile }.forEach { file ->
-            snapshot[file] = FileSnapshot(file.lastModified(), file.length())
+    internal fun buildFileSnapshot(): MutableMap<String, FileSnapshot> {
+        val snapshot = mutableMapOf<String, FileSnapshot>()
+        sequenceOf(workingDir.resolve("resources"), otherResourcesRootDirectory).forEach { dir ->
+            dir.walkTopDown().filter { it.isFile }.forEach { file ->
+                snapshot[pathKey(file)] = FileSnapshot(file.lastModified(), file.length())
+            }
         }
         return snapshot
     }
@@ -145,7 +167,7 @@ internal class ArsclibResourceCoder(
                 val relativePath = file.relativeTo(packageDir).invariantSeparatorsPath
                 if (excludedPaths.contains(relativePath)) return@forEach
 
-                val cached = fileSnapshotCache[file]
+                val cached = fileSnapshotCache[pathKey(file)]
                 if (cached == null || file.lastModified() != cached.lastModified || file.length() != cached.size) {
                     modifiedResResources.add(file)
                 }
@@ -153,13 +175,16 @@ internal class ArsclibResourceCoder(
         }
 
         otherResourcesRootDirectory.walkTopDown().filter { it.isFile }.forEach { file ->
-            val extractedHash = lazilyExtractedRootFiles[file]
-            if (extractedHash != null) {
-                // Extracted mid-run, so a timestamp comparison is unreliable here.
-                if (file.readBytes().contentHashCode() != extractedHash) modifiedBinaryResources.add(file)
+            val extracted = lazilyExtractedRootFiles[pathKey(file)]
+            if (extracted != null) {
+                // Extracted mid-run, so a timestamp comparison is unreliable here; compare the
+                // content instead, length first since that settles most edits without a read.
+                if (file.length() != extracted.length ||
+                    file.readBytes().contentHashCode() != extracted.hash
+                ) modifiedBinaryResources.add(file)
                 return@forEach
             }
-            val cached = fileSnapshotCache[file]
+            val cached = fileSnapshotCache[pathKey(file)]
             if (cached == null || file.lastModified() != cached.lastModified || file.length() != cached.size) {
                 modifiedBinaryResources.add(file)
             }
@@ -168,13 +193,13 @@ internal class ArsclibResourceCoder(
         // Detect files that existed at decode time but are now removed.
         // These need to be communicated to applyTo() so that they're excluded from the rebuilt APK.
         val rootPathPrefix = otherResourcesRootDirectory.absoluteFile.invariantSeparatorsPath
-        fileSnapshotCache.keys.forEach { snapshotFile ->
+        fileSnapshotCache.keys.forEach { key ->
+            val snapshotFile = File(key)
             if (snapshotFile.exists()) return@forEach
-            val absPath = snapshotFile.absoluteFile.invariantSeparatorsPath
-            if (absPath.startsWith("$rootPathPrefix/")) {
+            if (key.startsWith("$rootPathPrefix/")) {
                 val relativePath = snapshotFile.relativeTo(otherResourcesRootDirectory).invariantSeparatorsPath
                 // applyTo matches against archive entry names, not on-disk aliases.
-                deletedFiles += pathMap.getOriginalName(relativePath) ?: relativePath
+                deletedFiles += archiveNameOf(relativePath)
             }
         }
     }
@@ -244,10 +269,6 @@ internal class ArsclibResourceCoder(
 
         // Build a snapshot of all file metadata after decoding, so we can detect
         // which files are added or modified when it's time to encode.
-        // Nothing is staged under it any more, but patches add files here and the change
-        // detection walks it.
-        otherResourcesRootDirectory.mkdirs()
-
         fileSnapshotCache = buildFileSnapshot()
         pathMap = readPathMap()
 
@@ -321,10 +342,15 @@ internal class ArsclibResourceCoder(
         // Libraries are not staged on disk, so mark them for deletion from the rebuilt APK
         // instead of deleting extracted copies. This is what NONE mode already does.
         ZFile.openReadOnly(apkFile).use { zFile ->
-            zFile.entries().map { it.centralDirectoryHeader.name }.filter { name ->
-                name.startsWith("lib/") &&
-                        CpuArchitecture.valueOfOrNull(name.split("/")[1]) !in keepArchitectures
-            }.forEach { strippedLibraries += it }
+            zFile.entries().forEach { entry ->
+                val name = entry.centralDirectoryHeader.name
+                val parts = name.split("/")
+                if (name.startsWith("lib/") && parts.size > 1 &&
+                    CpuArchitecture.valueOfOrNull(parts[1]) !in keepArchitectures
+                ) {
+                    strippedLibraries += name
+                }
+            }
         }
 
         // A patch may have pulled one of these in; drop the staged copy so it is not re-added.
@@ -348,7 +374,8 @@ internal class ArsclibResourceCoder(
         // than skipping: adding or removing the attribute is exactly the interesting case.
         val original = originalExtractNativeLibs ?: true
         val current = Document(getFile("AndroidManifest.xml")).use { manifest ->
-            val node = manifest.getElementsByTagName("application").item(0) as? Element ?: return
+            val node = manifest.getElementsByTagName("application").item(0) as? Element
+                ?: return@use null
             node.getAttribute("android:extractNativeLibs").takeIf { it.isNotEmpty() }?.toBooleanStrictOrNull()
         } ?: true
         if (current == original) return
@@ -356,9 +383,10 @@ internal class ArsclibResourceCoder(
         logger.info("extractNativeLibs changed to $current, restaging native libraries")
         val staging = workingDir.resolve(PATCHED_ROOT_DIRECTORY)
         ZFile.openReadOnly(apkFile).use { zFile ->
-            zFile.entries().map { it.centralDirectoryHeader.name }
-                .filter { it.startsWith("lib/") && !it.endsWith("/") && it !in strippedLibraries }
-                .forEach { name ->
+            zFile.entries().forEach entries@{ entry ->
+                    val name = entry.centralDirectoryHeader.name
+                    if (!name.startsWith("lib/") || name.endsWith("/") ||
+                        name in strippedLibraries) return@entries
                     // Straight into the staging directory: these only need to reach the output,
                     // no patch is going to read them.
                     val destination = staging.resolve(name)
@@ -369,7 +397,7 @@ internal class ArsclibResourceCoder(
                         }
                     }
                     if (destination.exists()) {
-                        relocatedRootFiles[destination] = name
+                        relocatedRootFiles[pathKey(destination)] = name
                         if (!current) uncompressedOverrides += name
                     }
                 }
@@ -384,9 +412,10 @@ internal class ArsclibResourceCoder(
         val staging = workingDir.resolve(PATCHED_ROOT_DIRECTORY)
 
         // An extraction a patch only read is already correct in the target apk.
+        val changed = modifiedBinaryResources.mapTo(mutableSetOf()) { pathKey(it) }
         lazilyExtractedRootFiles.keys
-            .filter { it !in modifiedBinaryResources }
-            .forEach { it.safelyDelete() }
+            .filter { it !in changed }
+            .forEach { File(it).safelyDelete() }
 
         modifiedBinaryResources.toList().forEach { file ->
             if (!file.exists()) return@forEach
@@ -394,7 +423,7 @@ internal class ArsclibResourceCoder(
             val destination = staging.resolve(aliased)
             destination.parentFile?.mkdirs()
             file.safelyMoveTo(destination)
-            relocatedRootFiles[destination] = pathMap.getOriginalName(aliased) ?: aliased
+            relocatedRootFiles[pathKey(destination)] = archiveNameOf(aliased)
             modifiedBinaryResources -= file
         }
     }
@@ -659,8 +688,8 @@ internal class ArsclibResourceCoder(
         // changed under root/ takes the same route raw mode has always used for them.
         // Root files a patch changed: relocated ones in FULL mode, and any still staged
         // under root/ in either mode.
-        relocatedRootFiles.forEach { (file, apkPath) ->
-            otherFiles[file] = otherResourcesDir.resolve(apkPath)
+        relocatedRootFiles.forEach { (key, apkPath) ->
+            otherFiles[File(key)] = otherResourcesDir.resolve(apkPath)
         }
         modifiedBinaryResources.forEach {
             val path = it.absoluteFile.invariantSeparatorsPath.replace(workingDirPath, "")
@@ -718,13 +747,15 @@ internal class ArsclibResourceCoder(
                 )
                 var strippedLibCount = 0
                 ZFile.openReadOnly(apkFile).use { zFile ->
-                    zFile.entries().map { entry ->
-                        entry.centralDirectoryHeader.name
-                    }.filter { name ->
-                        name.startsWith("lib/") && CpuArchitecture.valueOfOrNull(name.split("/")[1]) !in keepArchitectures
-                    }.forEach { name ->
-                        add(name)
-                        strippedLibCount++
+                    zFile.entries().forEach { entry ->
+                        val name = entry.centralDirectoryHeader.name
+                        val parts = name.split("/")
+                        if (name.startsWith("lib/") && parts.size > 1 &&
+                            CpuArchitecture.valueOfOrNull(parts[1]) !in keepArchitectures
+                        ) {
+                            add(name)
+                            strippedLibCount++
+                        }
                     }
                 }
                 logger.info("Stripped $strippedLibCount lib files")
@@ -778,7 +809,7 @@ internal class ArsclibResourceCoder(
      */
     private fun extractRootEntries(aliasedPath: String) {
         // The working directory holds on-disk alias paths, the archive holds original names.
-        val apkPath = pathMap.getOriginalName(aliasedPath) ?: aliasedPath
+        val apkPath = archiveNameOf(aliasedPath)
         ZFile.openReadOnly(apkFile).use { zFile ->
             val exact = zFile.get(apkPath)
             if (exact != null) {
@@ -787,17 +818,17 @@ internal class ArsclibResourceCoder(
             }
             // A patch may ask for a directory (and then list it), which staging used to provide.
             val prefix = "${apkPath.trimEnd('/')}/"
-            zFile.entries().map { it.centralDirectoryHeader.name }
-                .filter { it.startsWith(prefix) }
-                .forEach { extractEntry(zFile, it) }
+            zFile.entries().forEach { entry ->
+                val name = entry.centralDirectoryHeader.name
+                if (name.startsWith(prefix)) extractEntry(zFile, name)
+            }
         }
     }
 
     private fun extractEntry(zFile: ZFile, apkPath: String) {
         val entry = zFile.get(apkPath) ?: return
         if (entry.centralDirectoryHeader.name.endsWith("/")) return
-        val destination = otherResourcesRootDirectory
-            .resolve(pathMap.getAlias(apkPath) ?: apkPath)
+        val destination = otherResourcesRootDirectory.resolve(aliasOf(apkPath))
         if (destination.exists()) return
         destination.parentFile?.mkdirs()
         entry.open().use { input ->
@@ -806,8 +837,9 @@ internal class ArsclibResourceCoder(
         if (!destination.exists()) return
         // Hash rather than (mtime, size): a patch usually rewrites the file within the same
         // filesystem timestamp tick, and same-length edits would otherwise read as unchanged.
-        lazilyExtractedRootFiles[destination] = destination.readBytes().contentHashCode()
-        fileSnapshotCache[destination] = FileSnapshot(destination.lastModified(), destination.length())
+        lazilyExtractedRootFiles[pathKey(destination)] =
+            ExtractedRootFile(destination.length(), destination.readBytes().contentHashCode())
+        fileSnapshotCache[pathKey(destination)] = FileSnapshot(destination.lastModified(), destination.length())
         logger.fine("Extracted root entry on demand: $apkPath")
     }
 

--- a/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
@@ -62,6 +62,13 @@ private const val SPARSE_ENTRIES_MIN_SDK = 26
  */
 private const val PATCHED_CONFIGURATIONS_DIRECTORY = "patched-configurations"
 
+/**
+ * Holds root files a patch changed while the resource apk is built. Outside the directories the
+ * encoder scans, so they travel through the other-files route only, instead of being compressed
+ * into resources.apk as well.
+ */
+private const val PATCHED_ROOT_DIRECTORY = "patched-root"
+
 internal class ArsclibResourceCoder(
     internal val workingDir: File,
     internal val apkFile: File,
@@ -87,13 +94,33 @@ internal class ArsclibResourceCoder(
      * Used to detect which files were added or modified between decoding and encoding.
      */
     internal data class FileSnapshot(val lastModified: Long, val size: Long)
-    internal var fileSnapshotCache: Map<File, FileSnapshot> = emptyMap()
+    internal var fileSnapshotCache: MutableMap<File, FileSnapshot> = mutableMapOf()
+
+    /**
+     * Root entries (lib/, assets/, ...) are left in the input APK instead of being
+     * staged to disk: [ApkUtils.applyTo] rebuilds the output from a copy of that same
+     * APK, so every unchanged root entry is already present and correct in the target.
+     * Only entries a patch actually asks for are extracted, by [getFile].
+     */
+    private val lazilyExtractedRootFiles = mutableMapOf<File, Int>()
+
+    /** Relocated root files, mapped to the archive entry name they must be written back as. */
+    private val relocatedRootFiles = mutableMapOf<File, String>()
+
+    /**
+     * Native library entries removed by [stripNativeLibraries], as in-APK paths.
+     * Held separately from [deletedFiles] because [detectFileChanges] clears that set.
+     */
+    private val strippedLibraries = mutableSetOf<String>()
+
+    /** Paths that must be stored uncompressed regardless of what the input APK did. */
+    private val uncompressedOverrides = mutableSetOf<String>()
     internal var pathMap: PathMap = PathMap.EMPTY
 
     /**
      * Recursively scan the working directory and build a map of file paths to their metadata.
      */
-    internal fun buildFileSnapshot(): Map<File, FileSnapshot> {
+    internal fun buildFileSnapshot(): MutableMap<File, FileSnapshot> {
         val snapshot = mutableMapOf<File, FileSnapshot>()
         workingDir.resolve("resources").walkTopDown().filter { it.isFile }.forEach { file ->
             snapshot[file] = FileSnapshot(file.lastModified(), file.length())
@@ -126,6 +153,12 @@ internal class ArsclibResourceCoder(
         }
 
         otherResourcesRootDirectory.walkTopDown().filter { it.isFile }.forEach { file ->
+            val extractedHash = lazilyExtractedRootFiles[file]
+            if (extractedHash != null) {
+                // Extracted mid-run, so a timestamp comparison is unreliable here.
+                if (file.readBytes().contentHashCode() != extractedHash) modifiedBinaryResources.add(file)
+                return@forEach
+            }
             val cached = fileSnapshotCache[file]
             if (cached == null || file.lastModified() != cached.lastModified || file.length() != cached.size) {
                 modifiedBinaryResources.add(file)
@@ -140,7 +173,8 @@ internal class ArsclibResourceCoder(
             val absPath = snapshotFile.absoluteFile.invariantSeparatorsPath
             if (absPath.startsWith("$rootPathPrefix/")) {
                 val relativePath = snapshotFile.relativeTo(otherResourcesRootDirectory).invariantSeparatorsPath
-                deletedFiles += relativePath
+                // applyTo matches against archive entry names, not on-disk aliases.
+                deletedFiles += pathMap.getOriginalName(relativePath) ?: relativePath
             }
         }
     }
@@ -160,9 +194,17 @@ internal class ArsclibResourceCoder(
         val signatureBlock: ApkSignatureBlock?
     )
 
+    /**
+     * `android:extractNativeLibs` as the input APK declares it. Libraries are not rebuilt into
+     * resources.apk any more, so if a patch flips this the target's own libraries would keep the
+     * old compression. [routeNativeLibrariesIfCompressionChanged] handles that case.
+     */
+    private var originalExtractNativeLibs: Boolean? = null
+
     private val lazyPackageInfo = lazy {
         ApkModule.loadApkFile(apkFile).use { module ->
             val manifest = module.androidManifest
+            originalExtractNativeLibs = manifest.isExtractNativeLibs
             PackageInfo(
                 manifest.packageName,
                 manifest.versionName,
@@ -202,6 +244,10 @@ internal class ArsclibResourceCoder(
 
         // Build a snapshot of all file metadata after decoding, so we can detect
         // which files are added or modified when it's time to encode.
+        // Nothing is staged under it any more, but patches add files here and the change
+        // detection walks it.
+        otherResourcesRootDirectory.mkdirs()
+
         fileSnapshotCache = buildFileSnapshot()
         pathMap = readPathMap()
 
@@ -210,7 +256,21 @@ internal class ArsclibResourceCoder(
 
     override fun decodeResources(): PackageMetadata {
         ApkModule.loadApkFile(apkFile).use { apkModule ->
-            val xmlDecoder = ApkModuleXmlDecoder(apkModule).also {
+            val xmlDecoder = object : ApkModuleXmlDecoder(apkModule) {
+                override fun extractRootFiles(mainDirectory: File) {
+                    // Anything still unclaimed at this point that lives under res/ is not
+                    // referenced by the resource table, and applyTo drops every res/ entry of
+                    // the target before merging, so those have to be staged after all.
+                    // Everything else stays in the input APK, see [extractRootEntries].
+                    var staged = 0
+                    apkModule.inputSources.forEach { source ->
+                        if (!source.alias.startsWith("res/")) addDecodedPath(source.alias)
+                        else if (!containsDecodedPath(source.alias)) staged++
+                    }
+                    if (staged != 0) logger.info("Staging $staged unreferenced res files")
+                    super.extractRootFiles(mainDirectory)
+                }
+            }.also {
                 it.setKeepResPath(false)
             }
 
@@ -238,6 +298,10 @@ internal class ArsclibResourceCoder(
 
         // Build a snapshot of all file metadata after decoding, so we can detect
         // which files are added or modified when it's time to encode.
+        // Nothing is staged under it any more, but patches add files here and the change
+        // detection walks it.
+        otherResourcesRootDirectory.mkdirs()
+
         fileSnapshotCache = buildFileSnapshot()
         pathMap = readPathMap()
 
@@ -249,21 +313,89 @@ internal class ArsclibResourceCoder(
      * This is a no-op if [keepArchitectures] is empty.
      */
     internal fun stripNativeLibraries() {
-        if (keepArchitectures.isNotEmpty()) {
-            logger.info("Stripping libs (keeping architectures " +
-                    "${keepArchitectures.joinToString(", ") { it.arch }})")
+        if (keepArchitectures.isEmpty()) return
 
-            var strippedLibCount = 0
-            otherResourcesRootDirectory.resolve("lib")
-                .takeIf { it.exists() }
-                ?.listFiles { dir ->
-                    dir.isDirectory && CpuArchitecture.valueOfOrNull(dir.name) !in keepArchitectures
-                }?.forEach { it ->
-                    it.walkTopDown().filter { it.isFile }.forEach { _ -> strippedLibCount++ }
-                    it.safelyDelete()
+        logger.info("Stripping libs (keeping architectures " +
+                "${keepArchitectures.joinToString(", ") { it.arch }})")
+
+        // Libraries are not staged on disk, so mark them for deletion from the rebuilt APK
+        // instead of deleting extracted copies. This is what NONE mode already does.
+        ZFile.openReadOnly(apkFile).use { zFile ->
+            zFile.entries().map { it.centralDirectoryHeader.name }.filter { name ->
+                name.startsWith("lib/") &&
+                        CpuArchitecture.valueOfOrNull(name.split("/")[1]) !in keepArchitectures
+            }.forEach { strippedLibraries += it }
+        }
+
+        // A patch may have pulled one of these in; drop the staged copy so it is not re-added.
+        otherResourcesRootDirectory.resolve("lib")
+            .takeIf { it.exists() }
+            ?.listFiles { dir ->
+                dir.isDirectory && CpuArchitecture.valueOfOrNull(dir.name) !in keepArchitectures
+            }?.forEach { it.safelyDelete() }
+
+        logger.info("Stripped ${strippedLibraries.size} lib files")
+    }
+
+    /**
+     * If a patch changed `android:extractNativeLibs`, the native libraries the target APK already
+     * holds are compressed the old way. Stage them so they travel through the other-files route
+     * and are re-added with the compression the new value calls for.
+     */
+    private fun routeNativeLibrariesIfCompressionChanged() {
+        lazyPackageInfo.value // populates originalExtractNativeLibs
+        // Absent means the platform default (true since API 23), so treat it as a value rather
+        // than skipping: adding or removing the attribute is exactly the interesting case.
+        val original = originalExtractNativeLibs ?: true
+        val current = Document(getFile("AndroidManifest.xml")).use { manifest ->
+            val node = manifest.getElementsByTagName("application").item(0) as? Element ?: return
+            node.getAttribute("android:extractNativeLibs").takeIf { it.isNotEmpty() }?.toBooleanStrictOrNull()
+        } ?: true
+        if (current == original) return
+
+        logger.info("extractNativeLibs changed to $current, restaging native libraries")
+        val staging = workingDir.resolve(PATCHED_ROOT_DIRECTORY)
+        ZFile.openReadOnly(apkFile).use { zFile ->
+            zFile.entries().map { it.centralDirectoryHeader.name }
+                .filter { it.startsWith("lib/") && !it.endsWith("/") && it !in strippedLibraries }
+                .forEach { name ->
+                    // Straight into the staging directory: these only need to reach the output,
+                    // no patch is going to read them.
+                    val destination = staging.resolve(name)
+                    if (!destination.exists()) {
+                        destination.parentFile?.mkdirs()
+                        zFile.get(name)?.open()?.use { input ->
+                            destination.outputStream().use { output -> input.copyTo(output) }
+                        }
+                    }
+                    if (destination.exists()) {
+                        relocatedRootFiles[destination] = name
+                        if (!current) uncompressedOverrides += name
+                    }
                 }
+        }
+    }
 
-            logger.info("Stripped $strippedLibCount lib files")
+    /**
+     * Take root files out of the directory the encoder scans: unchanged ones are already in the
+     * target APK, and changed ones are written back through the other-files route.
+     */
+    private fun relocateChangedRootFiles() {
+        val staging = workingDir.resolve(PATCHED_ROOT_DIRECTORY)
+
+        // An extraction a patch only read is already correct in the target apk.
+        lazilyExtractedRootFiles.keys
+            .filter { it !in modifiedBinaryResources }
+            .forEach { it.safelyDelete() }
+
+        modifiedBinaryResources.toList().forEach { file ->
+            if (!file.exists()) return@forEach
+            val aliased = file.relativeTo(otherResourcesRootDirectory).invariantSeparatorsPath
+            val destination = staging.resolve(aliased)
+            destination.parentFile?.mkdirs()
+            file.safelyMoveTo(destination)
+            relocatedRootFiles[destination] = pathMap.getOriginalName(aliased) ?: aliased
+            modifiedBinaryResources -= file
         }
     }
 
@@ -276,6 +408,9 @@ internal class ArsclibResourceCoder(
 
         // Detect which files were added or modified since decoding.
         detectFileChanges()
+
+        routeNativeLibrariesIfCompressionChanged()
+        relocateChangedRootFiles()
 
         val newPackageName = Document(getFile("AndroidManifest.xml")).use { manifest ->
             val manifestNode = manifest.getElementsByTagName("manifest").item(0) as Element
@@ -500,12 +635,12 @@ internal class ArsclibResourceCoder(
             }
         }
 
+        val workingDirPath = workingDir.absoluteFile.invariantSeparatorsPath
+
         // Add all touched files to the other files list in raw only mode since we won't be creating a resources.apk.
         if (resourceMode == ResourceMode.RAW_ONLY) {
             // Detect which files were added or modified since decoding.
             detectFileChanges()
-
-            val workingDirPath = workingDir.absoluteFile.invariantSeparatorsPath
 
             modifiedResResources.forEach {
                 val path = it.absoluteFile.invariantSeparatorsPath.replace(workingDirPath, "")
@@ -514,17 +649,24 @@ internal class ArsclibResourceCoder(
                 otherFiles[it] = otherResourcesDir.resolve(unaliasedPath)
             }
 
-            modifiedBinaryResources.forEach {
-                val path = it.absoluteFile.invariantSeparatorsPath.replace(workingDirPath, "")
-                val subPath = path.substringAfter("/root/")
-                val unaliasedPath = pathMap.getOriginalName(subPath) ?: subPath
-                otherFiles[it] = otherResourcesDir.resolve(unaliasedPath)
-            }
-
             val binaryManifest = workingDir.resolve("AndroidManifest.xml.bin")
             if (binaryManifest.exists()) {
                 otherFiles[binaryManifest] = workingDir.resolve("AndroidManifest.xml")
             }
+        }
+
+        // Root entries no longer travel inside resources.apk, so anything a patch added or
+        // changed under root/ takes the same route raw mode has always used for them.
+        // Root files a patch changed: relocated ones in FULL mode, and any still staged
+        // under root/ in either mode.
+        relocatedRootFiles.forEach { (file, apkPath) ->
+            otherFiles[file] = otherResourcesDir.resolve(apkPath)
+        }
+        modifiedBinaryResources.forEach {
+            val path = it.absoluteFile.invariantSeparatorsPath.replace(workingDirPath, "")
+            val subPath = path.substringAfter("/root/")
+            val unaliasedPath = pathMap.getOriginalName(subPath) ?: subPath
+            otherFiles[it] = otherResourcesDir.resolve(unaliasedPath)
         }
 
         return if (otherFiles.isNotEmpty()) {
@@ -540,9 +682,15 @@ internal class ArsclibResourceCoder(
 
     override fun getUncompressedFiles(resourceMode: ResourceMode): Set<String> {
         val uncompressedJsonFile = workingDir.resolve("uncompressed-files.json")
-        if (!uncompressedJsonFile.exists()) return emptySet()
+        if (!uncompressedJsonFile.exists()) return uncompressedOverrides.toSet()
 
-        return UncompressedFiles(uncompressedJsonFile.readText(Charsets.UTF_8), pathMap)
+        // Defensive copy: close() clears the backing set, and applyTo commonly runs after the
+        // enclosing Patcher use block. Same reason getDeletedFiles copies.
+        return UncompressedFiles(
+            uncompressedJsonFile.readText(Charsets.UTF_8),
+            pathMap,
+            uncompressedOverrides.toSet(),
+        )
     }
 
     /**
@@ -580,9 +728,9 @@ internal class ArsclibResourceCoder(
                     }
                 }
                 logger.info("Stripped $strippedLibCount lib files")
-            } + deletedFiles
+            } + deletedFiles + strippedLibraries
         } else {
-            deletedFiles.toSet()
+            deletedFiles + strippedLibraries
         }
 
     /**
@@ -590,7 +738,9 @@ internal class ArsclibResourceCoder(
      *
      * @param path The path of the file.
      * @param packageName The package name of the file. Defaults to the package name of the APK.
-     * @param copy No-op for backwards compatibility with APKTool. All files from the APK are always available.
+     * @param copy Whether to extract the file from [apkFile] if it is not staged in the working
+     * directory yet. Root entries are not staged by [decodeResources], so this is what makes
+     * `assets/` and `lib/` reachable from a patch.
      * @return a File object representing the desired file.
      */
     override fun getFile(
@@ -598,20 +748,67 @@ internal class ArsclibResourceCoder(
         packageName: String?,
         copy: Boolean,
     ): File {
-        val pkgName = packageName ?: lazyPackageInfo.value.packageName
-
         val aliasedPath = pathMap.getAlias(path) ?: path
 
         val retval = if (aliasedPath == "res" || aliasedPath.startsWith("res/") || aliasedPath == "package.json") {
+            // Only resource paths are package scoped, so do not read the manifest for the rest.
+            val pkgName = packageName ?: lazyPackageInfo.value.packageName
             packageDirectories[pkgName]?.resolve(aliasedPath) ?: throw PatchException("Package $pkgName not found")
         } else if (aliasedPath == "AndroidManifest.xml") {
             // TODO: Doesn't handle modifications to binary AndroidManifest.xml, but then again neither does apktool in raw mode.
             workingDir.resolve(aliasedPath)
         } else {
-            otherResourcesRootDirectory.resolve(aliasedPath)
+            otherResourcesRootDirectory.resolve(aliasedPath).also { file ->
+                if (!file.exists()) {
+                    extractRootEntries(aliasedPath)
+                    // Not in the archive either, so a patch is adding it; staging used to
+                    // guarantee the directory existed for that.
+                    if (!file.exists()) file.parentFile?.mkdirs()
+                }
+            }
         }
 
         return retval
+    }
+
+    /**
+     * Extract a single root entry from the input APK into the working directory, and record it
+     * in the snapshot so that [detectFileChanges] treats it as pre-existing rather than added.
+     * A patch that goes on to modify or delete it is then detected exactly as before.
+     */
+    private fun extractRootEntries(aliasedPath: String) {
+        // The working directory holds on-disk alias paths, the archive holds original names.
+        val apkPath = pathMap.getOriginalName(aliasedPath) ?: aliasedPath
+        ZFile.openReadOnly(apkFile).use { zFile ->
+            val exact = zFile.get(apkPath)
+            if (exact != null) {
+                extractEntry(zFile, apkPath)
+                return@use
+            }
+            // A patch may ask for a directory (and then list it), which staging used to provide.
+            val prefix = "${apkPath.trimEnd('/')}/"
+            zFile.entries().map { it.centralDirectoryHeader.name }
+                .filter { it.startsWith(prefix) }
+                .forEach { extractEntry(zFile, it) }
+        }
+    }
+
+    private fun extractEntry(zFile: ZFile, apkPath: String) {
+        val entry = zFile.get(apkPath) ?: return
+        if (entry.centralDirectoryHeader.name.endsWith("/")) return
+        val destination = otherResourcesRootDirectory
+            .resolve(pathMap.getAlias(apkPath) ?: apkPath)
+        if (destination.exists()) return
+        destination.parentFile?.mkdirs()
+        entry.open().use { input ->
+            destination.outputStream().use { output -> input.copyTo(output) }
+        }
+        if (!destination.exists()) return
+        // Hash rather than (mtime, size): a patch usually rewrites the file within the same
+        // filesystem timestamp tick, and same-length edits would otherwise read as unchanged.
+        lazilyExtractedRootFiles[destination] = destination.readBytes().contentHashCode()
+        fileSnapshotCache[destination] = FileSnapshot(destination.lastModified(), destination.length())
+        logger.fine("Extracted root entry on demand: $apkPath")
     }
 
     /**
@@ -643,6 +840,10 @@ internal class ArsclibResourceCoder(
         modifiedResResources.clear()
         modifiedBinaryResources.clear()
         deletedFiles.clear()
-        fileSnapshotCache = emptyMap()
+        lazilyExtractedRootFiles.clear()
+        relocatedRootFiles.clear()
+        strippedLibraries.clear()
+        uncompressedOverrides.clear()
+        fileSnapshotCache = mutableMapOf()
     }
 }

--- a/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
@@ -154,7 +154,7 @@ internal class ArsclibResourceCoderTest {
         val resDir = pkgDir.resolve("res")
 
         // Snapshot is empty (no files existed at decode time).
-        coder.fileSnapshotCache = emptyMap()
+        coder.fileSnapshotCache = mutableMapOf()
 
         // Create a new file after "decoding".
         val newFile = resDir.resolve("drawable").also { it.mkdirs() }.resolve("icon.xml")
@@ -199,7 +199,7 @@ internal class ArsclibResourceCoderTest {
         val originalSize = file.length()
         val snapshotEntry = ArsclibResourceCoder.FileSnapshot(originalLastModified, originalSize)
 
-        coder.fileSnapshotCache = mapOf(file to snapshotEntry)
+        coder.fileSnapshotCache = mutableMapOf(file to snapshotEntry)
 
         // Change the content (and thus the size) but preserve the timestamp.
         file.writeText("this is a much longer string to change the file size")
@@ -237,7 +237,7 @@ internal class ArsclibResourceCoderTest {
         publicXml.writeText("<resources/>")
 
         // Empty snapshot — file would normally be "added".
-        coder.fileSnapshotCache = emptyMap()
+        coder.fileSnapshotCache = mutableMapOf()
 
         coder.detectFileChanges()
 
@@ -252,7 +252,7 @@ internal class ArsclibResourceCoderTest {
         val idsXml = resDir.resolve("values").also { it.mkdirs() }.resolve("ids.xml")
         idsXml.writeText("<resources/>")
 
-        coder.fileSnapshotCache = emptyMap()
+        coder.fileSnapshotCache = mutableMapOf()
 
         coder.detectFileChanges()
 
@@ -309,7 +309,7 @@ internal class ArsclibResourceCoderTest {
 
         // Empty snapshot, no files on disk in res (delete the stale file).
         staleFile.delete()
-        coder.fileSnapshotCache = emptyMap()
+        coder.fileSnapshotCache = mutableMapOf()
 
         coder.detectFileChanges()
 
@@ -327,7 +327,7 @@ internal class ArsclibResourceCoderTest {
         pkgDir2.resolve("res").mkdirs()
         coder.packageDirectories["com.test.lib"] = pkgDir2
 
-        coder.fileSnapshotCache = emptyMap()
+        coder.fileSnapshotCache = mutableMapOf()
 
         // Add a file in each package.
         val file1 = pkgDir1.resolve("res/drawable").also { it.mkdirs() }.resolve("a.xml")
@@ -351,7 +351,7 @@ internal class ArsclibResourceCoderTest {
         val nonResFile = pkgDir.resolve("some_other_file.txt")
         nonResFile.writeText("not a resource")
 
-        coder.fileSnapshotCache = emptyMap()
+        coder.fileSnapshotCache = mutableMapOf()
 
         coder.detectFileChanges()
 
@@ -400,7 +400,7 @@ internal class ArsclibResourceCoderTest {
     @Test
     fun `detectFileChanges identifies newly added files in otherResourcesRootDirectory`() {
         // No package directories — simulates FULL mode where files are added to root/.
-        coder.fileSnapshotCache = emptyMap()
+        coder.fileSnapshotCache = mutableMapOf()
 
         val rootDir = workingDir.resolve("root").also { it.mkdirs() }
         val newFile = rootDir.resolve("assets").also { it.mkdirs() }.resolve("config.json")
@@ -455,7 +455,7 @@ internal class ArsclibResourceCoderTest {
         val rootDir = workingDir.resolve("root").also { it.mkdirs() }
 
         // Snapshot is empty — no files existed after raw decoding.
-        coder.fileSnapshotCache = emptyMap()
+        coder.fileSnapshotCache = mutableMapOf()
 
         // A patch adds a new file.
         val newFile = rootDir.resolve("raw").also { it.mkdirs() }
@@ -537,7 +537,7 @@ internal class ArsclibResourceCoderTest {
         // Also create a non-excluded file
         val stringsXml = valuesDir.resolve("strings.xml").also { it.writeText("<resources/>") }
 
-        coder.fileSnapshotCache = emptyMap()
+        coder.fileSnapshotCache = mutableMapOf()
         coder.detectFileChanges()
 
         // Verify excluded files are NOT detected
@@ -770,7 +770,7 @@ internal class ArsclibResourceCoderTest {
         val drawableDir = resDir.resolve("drawable-mdpi").also { it.mkdirs() }
         val aliasFile = drawableDir.resolve("drawable_0x7f080695.png").also { it.writeText("PNG") }
 
-        coder.fileSnapshotCache = emptyMap()
+        coder.fileSnapshotCache = mutableMapOf()
         coder.pathMap = PathMap("""[
             {"name": "res/-5N.png", "alias": "res/drawable-mdpi/drawable_0x7f080695.png"}
         ]""")
@@ -792,7 +792,7 @@ internal class ArsclibResourceCoderTest {
         val aliasDir = rootDir.resolve("assets/data").also { it.mkdirs() }
         aliasDir.resolve("config_aliased.bin").also { it.writeBytes(byteArrayOf(0x01)) }
 
-        coder.fileSnapshotCache = emptyMap()
+        coder.fileSnapshotCache = mutableMapOf()
         coder.pathMap = PathMap("""[
             {"name": "assets/config.bin", "alias": "assets/data/config_aliased.bin"}
         ]""")
@@ -813,7 +813,7 @@ internal class ArsclibResourceCoderTest {
         val valuesDir = resDir.resolve("values").also { it.mkdirs() }
         valuesDir.resolve("strings.xml").also { it.writeText("<resources/>") }
 
-        coder.fileSnapshotCache = emptyMap()
+        coder.fileSnapshotCache = mutableMapOf()
         coder.pathMap = PathMap("""[
             {"name": "res/-5N.png", "alias": "res/drawable-mdpi/drawable_0x7f080695.png"}
         ]""")
@@ -846,7 +846,7 @@ internal class ArsclibResourceCoderTest {
         val libDir = rootDir.resolve("lib/arm64-v8a").also { it.mkdirs() }
         libDir.resolve("libfoo.so").also { it.writeBytes(byteArrayOf(0x7F, 0x45, 0x4C, 0x46)) }
 
-        coder.fileSnapshotCache = emptyMap()
+        coder.fileSnapshotCache = mutableMapOf()
         coder.pathMap = PathMap("""[
             {"name": "res/-5N.png", "alias": "res/drawable-mdpi/drawable_0x7f080695.png"}
         ]""")
@@ -872,7 +872,7 @@ internal class ArsclibResourceCoderTest {
         val drawableDir = resDir.resolve("drawable").also { it.mkdirs() }
         drawableDir.resolve("icon.png").also { it.writeText("PNG") }
 
-        coder.fileSnapshotCache = emptyMap()
+        coder.fileSnapshotCache = mutableMapOf()
         coder.pathMap = PathMap.EMPTY
 
         val outputDir = workingDir.resolveSibling("output").also { it.mkdirs() }
@@ -896,6 +896,138 @@ internal class ArsclibResourceCoderTest {
         val dummyApk = tempDir.resolve("dummy2.apk")
         ZFile.openReadWrite(dummyApk).use { }
         return ArsclibResourceCoder(workingDir, dummyApk, keepArchitectures)
+    }
+
+    // ==================== root entries left in the input apk ====================
+
+    /**
+     * Build an apk holding root entries, so the paths that no longer stage anything to disk
+     * can be exercised against a real archive rather than against files a test pre-created.
+     */
+    private fun createApkWithRootEntries(tempDir: File, entries: Map<String, String>): File {
+        val apk = tempDir.resolve("withroot.apk")
+        ZFile.openReadWrite(apk).use { zFile ->
+            entries.forEach { (name, content) ->
+                zFile.add(name, ByteArrayInputStream(content.toByteArray()))
+            }
+        }
+        return apk
+    }
+
+    @Test
+    fun `getFile extracts a root entry that was never staged`(@TempDir tempDir: File) {
+        val apk = createApkWithRootEntries(tempDir, mapOf("assets/data.bin" to "payload"))
+        val rootCoder = ArsclibResourceCoder(workingDir, apk)
+
+        val file = rootCoder.getFile("assets/data.bin")
+
+        assertTrue(file.exists(), "Root entry should be extracted on demand")
+        assertEquals("payload", file.readText())
+    }
+
+    @Test
+    fun `getFile extracts an aliased root entry by its archive name`(@TempDir tempDir: File) {
+        val apk = createApkWithRootEntries(tempDir, mapOf("assets/o.bin" to "aliased"))
+        val rootCoder = ArsclibResourceCoder(workingDir, apk)
+        rootCoder.pathMap = PathMap("""[{"name":"assets/o.bin","alias":"assets/original.bin"}]""")
+
+        // Patches address files by the readable name, which the archive does not use.
+        val file = rootCoder.getFile("assets/original.bin")
+
+        assertTrue(file.exists(), "Aliased root entry should resolve to its archive name")
+        assertEquals("aliased", file.readText())
+    }
+
+    @Test
+    fun `getFile extracts every entry of a requested root directory`(@TempDir tempDir: File) {
+        val apk = createApkWithRootEntries(
+            tempDir,
+            mapOf("assets/dir/a.bin" to "a", "assets/dir/b.bin" to "b", "assets/other.bin" to "c")
+        )
+        val rootCoder = ArsclibResourceCoder(workingDir, apk)
+
+        val dir = rootCoder.getFile("assets/dir")
+
+        assertTrue(dir.isDirectory, "A requested directory should be materialised")
+        assertEquals(setOf("a.bin", "b.bin"), dir.listFiles()!!.map { it.name }.toSet())
+    }
+
+    @Test
+    fun `getFile gives a patch somewhere to create a new root file`(@TempDir tempDir: File) {
+        // A patch adding e.g. a branding file writes to a path the input apk never had, and
+        // staging used to be what created the directory for it.
+        val apk = createApkWithRootEntries(tempDir, mapOf("assets/data.bin" to "payload"))
+        val rootCoder = ArsclibResourceCoder(workingDir, apk)
+
+        val file = rootCoder.getFile("BRANDING.TXT")
+        file.writeText("added by a patch")
+
+        assertEquals("added by a patch", file.readText())
+    }
+
+    @Test
+    fun `getFile creates nested parents for a new root file`(@TempDir tempDir: File) {
+        val apk = createApkWithRootEntries(tempDir, mapOf("assets/data.bin" to "payload"))
+        val rootCoder = ArsclibResourceCoder(workingDir, apk)
+
+        val file = rootCoder.getFile("assets/new/nested.txt")
+        file.writeText("nested")
+
+        assertEquals("nested", file.readText())
+    }
+
+    @Test
+    fun `getFile leaves a path that the apk does not hold`(@TempDir tempDir: File) {
+        val apk = createApkWithRootEntries(tempDir, mapOf("assets/data.bin" to "payload"))
+        val rootCoder = ArsclibResourceCoder(workingDir, apk)
+
+        assertFalse(rootCoder.getFile("assets/missing.bin").exists())
+    }
+
+    @Test
+    fun `detectFileChanges sees a same-length rewrite of an extracted root file`(
+        @TempDir tempDir: File
+    ) {
+        val apk = createApkWithRootEntries(tempDir, mapOf("assets/data.bin" to "aaaa"))
+        val rootCoder = ArsclibResourceCoder(workingDir, apk)
+        val file = rootCoder.getFile("assets/data.bin")
+
+        // Same length and, on a coarse filesystem clock, the same timestamp.
+        file.writeText("bbbb")
+        file.setLastModified(file.lastModified())
+        rootCoder.detectFileChanges()
+
+        assertTrue(
+            file in rootCoder.modifiedBinaryResources,
+            "A same-length rewrite must still count as modified"
+        )
+    }
+
+    @Test
+    fun `stripNativeLibraries marks libs for deletion without anything staged`(
+        @TempDir tempDir: File
+    ) {
+        val apk = createApkWithLibs(tempDir, listOf("arm64-v8a", "x86"))
+        val archCoder = ArsclibResourceCoder(workingDir, apk, setOf(CpuArchitecture.ARM64_V8A))
+
+        archCoder.stripNativeLibraries()
+        val deleted = archCoder.getDeletedFiles(ResourceMode.FULL)
+
+        assertTrue(deleted.all { it.startsWith("lib/x86/") }, "Only the dropped arch: $deleted")
+        assertEquals(2, deleted.size, "Both x86 entries should be marked")
+    }
+
+    @Test
+    fun `getUncompressedFiles survives close`(@TempDir tempDir: File) {
+        val apk = createApkWithRootEntries(tempDir, mapOf("assets/a" to "a"))
+        val rootCoder = ArsclibResourceCoder(workingDir, apk)
+        workingDir.resolve("uncompressed-files.json").writeText("""{"paths":["lib/x86/libfoo.so"]}""")
+
+        val uncompressed = rootCoder.getUncompressedFiles(ResourceMode.FULL)
+        // applyTo commonly reads this after the patcher has been closed.
+        rootCoder.close()
+
+        assertTrue("lib/x86/libfoo.so" in uncompressed, "Result must not alias cleared state")
     }
 
     /**

--- a/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
@@ -22,6 +22,9 @@ import kotlin.test.assertTrue
 
 internal class ArsclibResourceCoderTest {
 
+    /** Mirrors the coder's canonical snapshot key. */
+    private val File.snapshotKey get() = absoluteFile.invariantSeparatorsPath
+
     private lateinit var workingDir: File
     private lateinit var coder: ArsclibResourceCoder
 
@@ -114,8 +117,8 @@ internal class ArsclibResourceCoderTest {
         val snapshot = coder.buildFileSnapshot()
 
         assertEquals(2, snapshot.size, "Snapshot should contain exactly 2 files")
-        assertTrue(snapshot.containsKey(fileA), "Snapshot should contain a.txt")
-        assertTrue(snapshot.containsKey(fileB), "Snapshot should contain sub/b.txt")
+        assertTrue(snapshot.containsKey(fileA.snapshotKey), "Snapshot should contain a.txt")
+        assertTrue(snapshot.containsKey(fileB.snapshotKey), "Snapshot should contain sub/b.txt")
     }
 
     @Test
@@ -124,7 +127,7 @@ internal class ArsclibResourceCoderTest {
         val file = pkgDir.resolve("test.txt").also { it.writeText("content") }
 
         val snapshot = coder.buildFileSnapshot()
-        val entry = snapshot[file]!!
+        val entry = snapshot[file.snapshotKey]!!
 
         assertEquals(file.lastModified(), entry.lastModified)
         assertEquals(file.length(), entry.size)
@@ -199,7 +202,7 @@ internal class ArsclibResourceCoderTest {
         val originalSize = file.length()
         val snapshotEntry = ArsclibResourceCoder.FileSnapshot(originalLastModified, originalSize)
 
-        coder.fileSnapshotCache = mutableMapOf(file to snapshotEntry)
+        coder.fileSnapshotCache = mutableMapOf(file.snapshotKey to snapshotEntry)
 
         // Change the content (and thus the size) but preserve the timestamp.
         file.writeText("this is a much longer string to change the file size")


### PR DESCRIPTION
### Description

Decoding in `ResourceMode.FULL` stages every non-DEX entry of the input APK to
`workingDir/root/` — for YouTube that is roughly 270 MB of `lib/*.so` and `assets/` — and
`encodeResources` then deflates all of it back into `resources.apk`.

None of those bytes reach the output. `applyTo` rebuilds the APK from a byte copy of the same
input file, and `ZFile.mergeFrom` skips a source entry whose name, uncompressed size and CRC32
match the target's, so every unchanged root entry is decompressed to disk, compressed again, and
then discarded by the merge. The staging is not a transport; the target already holds those
entries.

What the staging does provide is a read surface: a patch can reach `assets/…` through
`get(path)`, native library stripping deletes staged directories, and modified root files ride
out inside `resources.apk`. This change keeps each of those working by a narrower route rather
than by extracting the whole archive up front.

### Changes

- Leave root entries in the input APK during decode.
- Extract a root entry on demand in `getFile`, which makes its long-ignored `copy` parameter do
  what `ResourceCoder` already documents. Extracted files are recorded in the snapshot so that a
  patch modifying or deleting one is still detected.
- Strip native libraries by enumerating the input APK and marking the entries for deletion, which
  is what `ResourceMode.NONE` already does, instead of deleting extracted copies.
- Route root files a patch added or changed through the other-files path that raw mode already
  uses for them.
- Restage native libraries explicitly if a patch changes `android:extractNativeLibs`, since the
  target's own libraries would otherwise keep the compression the old value implied.

### Validation

- `./gradlew test` passes, including new cases for extracting a root entry on demand, an
  aliased one, a requested directory, a patch adding a root file the input APK never had,
  same-length rewrites, library stripping with nothing staged, and the uncompressed set
  outliving `close()`.
- On an Android 15 emulator, patching YouTube 21.04.223 with the 78 default patches: the run
  completes with no patch errors, and `workingDir/root/` holds 8-64 KB during it instead of
  277 MB. The resulting APK installs through the system installer and runs — `HomeActivity`
  reaches the foreground with no crash, `UnsatisfiedLinkError` or `dlopen` failure.
- Comparing that output against the input APK: all 120 native libraries and all 386 assets are
  byte-identical, the 254 `com/` and 378 `org/` entries survive, a root file added by a patch is
  present, and the only entry missing is `stamp-cert-sha256`, which patched APKs built before
  this change also drop.

### Measurement

Host, decode + encode + write of YouTube 21.04.223 outside the patcher, mean of 3 alternating
runs with a pinned heap:

| phase | before | after |
|---|---|---|
| decode | 11.4 s | 8.8 s |
| encode | 8.1 s | 8.0 s |
| write | 31.2 s | 6.8 s |
| **total** | **50.7 s** | **23.6 s** |

The working directory goes from 366 MB to 100 MB and `resources.apk` from 151 MB to 32 MB, and
the resource entries of the two outputs are identical: same 15,048 entries, no difference in
content or compression method.

On the emulator, one run per side of a full patch, so treat these as indicative rather than
precise — the emulator is CPU throttled and the DEX phases, which this does not touch, dominate:
decoding 37.5 s to 29.3 s, writing the resource APK 118.0 s to 87.2 s, whole patch 327 s to
293 s. `resources.apk` was 38 MB.

The device gains should understate what a real phone sees: most of what this removes is writing
and re-reading a few hundred megabytes, and the emulator is backed by host storage.

### Notes

These changes were developed and measured with AI assistance.
