### PR TITLE
fix: Report a deleted root file when the working directory is relative

### DIFF
--- a/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
@@ -194,10 +194,12 @@ internal class ArsclibResourceCoder(
         // These need to be communicated to applyTo() so that they're excluded from the rebuilt APK.
         val rootPathPrefix = otherResourcesRootDirectory.absoluteFile.invariantSeparatorsPath
         fileSnapshotCache.keys.forEach { key ->
-            val snapshotFile = File(key)
-            if (snapshotFile.exists()) return@forEach
+            if (File(key).exists()) return@forEach
             if (key.startsWith("$rootPathPrefix/")) {
-                val relativePath = snapshotFile.relativeTo(otherResourcesRootDirectory).invariantSeparatorsPath
+                // Snapshot keys are absolute while the working directory may be relative
+                // (PatcherConfig defaults it to one), and relativising across that throws.
+                // The prefix has already matched, so take the remainder of the key.
+                val relativePath = key.removePrefix("$rootPathPrefix/")
                 // applyTo matches against archive entry names, not on-disk aliases.
                 deletedFiles += archiveNameOf(relativePath)
             }

--- a/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
@@ -980,6 +980,31 @@ internal class ArsclibResourceCoderTest {
     }
 
     @Test
+    fun `detectFileChanges reports a deleted root file with a relative working directory`(
+        @TempDir tempDir: File
+    ) {
+        // PatcherConfig.temporaryFilesPath defaults to a relative path, so the coder's working
+        // directory is commonly relative while the snapshot keys are absolute.
+        val apk = createApkWithRootEntries(tempDir, mapOf("assets/data.bin" to "payload"))
+        val relativeDir = File("build/tmp/relative-working-dir-${System.nanoTime()}")
+        try {
+            val relativeCoder = ArsclibResourceCoder(relativeDir, apk)
+            val file = relativeCoder.getFile("assets/data.bin")
+            assertTrue(file.exists(), "precondition: the entry is extracted")
+            file.delete()
+
+            relativeCoder.detectFileChanges()
+
+            assertTrue(
+                "assets/data.bin" in relativeCoder.getDeletedFiles(ResourceMode.FULL),
+                "A deleted root file must be reported for removal from the rebuilt apk"
+            )
+        } finally {
+            relativeDir.deleteRecursively()
+        }
+    }
+
+    @Test
     fun `getFile leaves a path that the apk does not hold`(@TempDir tempDir: File) {
         val apk = createApkWithRootEntries(tempDir, mapOf("assets/data.bin" to "payload"))
         val rootCoder = ArsclibResourceCoder(workingDir, apk)


### PR DESCRIPTION
### Description

A regression I introduced in the review pass on #188.

That change made the file-snapshot keys absolute path strings, but the deleted-file detection still relativised a key against the working directory. `PatcherConfig` defaults `temporaryFilesPath` to a relative path, and `File.relativeTo` throws when the two sides differ in rootedness, so a patch deleting a root file it had read fails the build:

```
java.lang.IllegalArgumentException: this and base files have different roots:
  /abs/path/working-dir/root/assets/data.bin and working-dir/root
```

The manager passes an absolute path so it cannot hit this; callers relying on the default can.

### Changes

- Take the deleted root path from the snapshot key, whose prefix has already been matched, instead of relativising.
- Add a regression test that fails on `dev`.

### Notes

These changes were developed with AI assistance.
