### PR TITLE
feat: Add function to list the entries of the APK being patched

### DIFF
--- a/api/morphe-patcher.api
+++ b/api/morphe-patcher.api
@@ -1064,6 +1064,8 @@ public final class app/morphe/patcher/patch/ResourcePatchContext : app/morphe/pa
 	public static synthetic fun get$default (Lapp/morphe/patcher/patch/ResourcePatchContext;Ljava/lang/String;ZILjava/lang/Object;)Ljava/io/File;
 	public fun getFileWorkspace ()Ljava/io/File;
 	public final fun getPackageMetadata ()Lapp/morphe/patcher/PackageMetadata;
+	public final fun listApkEntries (Ljava/lang/String;)Ljava/util/List;
+	public static synthetic fun listApkEntries$default (Lapp/morphe/patcher/patch/ResourcePatchContext;Ljava/lang/String;ILjava/lang/Object;)Ljava/util/List;
 }
 
 public final class app/morphe/patcher/patch/SliderOptionsKt {

--- a/docs/4_apis.md
+++ b/docs/4_apis.md
@@ -8,6 +8,7 @@ A handful of APIs are available to make patch development easier and more effici
 2. 🔄️️ Change immutable classes to mutable with `mutableClassDefBy(ClassDef)
 3. 💾 Read and write resource files with `get(String, Boolean)` and `delete(String)`
 4. 📃 Read and write DOM files using `document(String)` and  `document(InputStream)`
+5. 📜 List the entries of the APK being patched with `listApkEntries(String)`
 
 ### 🧰 APIs
 
@@ -87,6 +88,23 @@ execute {
     }
 }
 ```
+
+#### 📜 `listApkEntries(String)`
+
+The `listApkEntries` function lists the entries of the APK being patched, without staging them
+to the working directory. Use it to discover what an APK contains, rather than walking the
+working directory: not every entry is staged there, and native libraries in particular are left
+in the archive. Names are archive names, so they can be passed straight to `get(String, Boolean)`.
+An optional prefix restricts the listing.
+
+```kt
+execute {
+    val nativeLibraries = listApkEntries("lib/")
+}
+```
+
+The listing describes the input APK, so it does not reflect files a patch has since added,
+changed or deleted.
 
 ## 🎉 Afterword
 

--- a/src/main/kotlin/app/morphe/patcher/patch/ResourcePatchContext.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/ResourcePatchContext.kt
@@ -100,6 +100,20 @@ class ResourcePatchContext internal constructor(
     ) = resourceCoder.getFile(path, copy = copy)
 
     /**
+     * List the entries of the APK being patched, without staging them to the working directory.
+     *
+     * Use this to discover what an APK contains, rather than walking the working directory: not
+     * every entry is staged there, and native libraries in particular are left in the archive.
+     * Names are archive names, so they can be passed straight to [get].
+     *
+     * The listing describes the input APK, so it does not reflect files a patch has since added,
+     * changed or deleted.
+     *
+     * @param prefix Restricts the listing to entries starting with it, e.g. `lib/`.
+     */
+    fun listApkEntries(prefix: String = "") = resourceCoder.listApkEntries(prefix)
+
+    /**
      * Mark a file for deletion when the APK is rebuilt.
      *
      * @param name The name of the file to delete.

--- a/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
@@ -808,6 +808,13 @@ internal class ArsclibResourceCoder(
         return retval
     }
 
+    override fun listApkEntries(prefix: String): List<String> =
+        ZFile.openReadOnly(apkFile).use { zFile ->
+            zFile.entries().mapNotNull { entry ->
+                entry.centralDirectoryHeader.name.takeIf { it.startsWith(prefix) }
+            }
+        }
+
     /**
      * Whether a root entry is staged to the working directory during decode. Everything is,
      * except native libraries: they are the bulk of an APK, and nothing enumerates them on disk.

--- a/src/main/kotlin/app/morphe/patcher/resource/coder/ResourceCoder.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/coder/ResourceCoder.kt
@@ -23,6 +23,19 @@ internal interface ResourceCoder : Closeable {
     fun getPackageMetadata(): PackageMetadata
 
     /**
+     * List the entries of the APK being patched, without reading them or staging them to the
+     * working directory.
+     *
+     * Names are archive names, as [getFile] accepts them. The listing describes the input APK, so
+     * it does not reflect files a patch has since added, changed or deleted.
+     *
+     * @param prefix Restricts the listing to entries starting with it, e.g. `lib/`. Empty lists
+     * every entry.
+     * @return The matching archive entry names.
+     */
+    fun listApkEntries(prefix: String = ""): List<String>
+
+    /**
      * Decode raw resources from the APK into the working directory and update the package metadata.
      *
      * @return The package's metadata.

--- a/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
@@ -901,6 +901,44 @@ internal class ArsclibResourceCoderTest {
         return ArsclibResourceCoder(workingDir, dummyApk, keepArchitectures)
     }
 
+    // ==================== listApkEntries ====================
+
+    @Test
+    fun `listApkEntries lists entries without staging them`(@TempDir tempDir: File) {
+        val apk = createApkWithRootEntries(
+            tempDir,
+            mapOf("lib/arm64-v8a/a.so" to "a", "lib/x86/b.so" to "b", "assets/c.bin" to "c")
+        )
+        val listCoder = ArsclibResourceCoder(workingDir, apk)
+
+        val libs = listCoder.listApkEntries("lib/")
+
+        assertEquals(setOf("lib/arm64-v8a/a.so", "lib/x86/b.so"), libs.toSet())
+        assertFalse(
+            workingDir.resolve("root/lib").exists(),
+            "Listing must not stage anything to the working directory"
+        )
+    }
+
+    @Test
+    fun `listApkEntries with no prefix lists every entry`(@TempDir tempDir: File) {
+        val apk = createApkWithRootEntries(tempDir, mapOf("assets/a" to "a", "top.txt" to "t"))
+        val listCoder = ArsclibResourceCoder(workingDir, apk)
+
+        assertEquals(setOf("assets/a", "top.txt"), listCoder.listApkEntries().toSet())
+    }
+
+    @Test
+    fun `listApkEntries returns names get accepts`(@TempDir tempDir: File) {
+        val apk = createApkWithRootEntries(tempDir, mapOf("assets/data.bin" to "payload"))
+        val listCoder = ArsclibResourceCoder(workingDir, apk)
+
+        val name = listCoder.listApkEntries("assets/").single()
+        val file = listCoder.getFile(name)
+
+        assertEquals("payload", file.readText())
+    }
+
     // ==================== which root entries are staged ====================
 
     @Test


### PR DESCRIPTION
### Description

A patch that needs to discover what an APK contains has had to walk the working directory, which only shows what decoding staged there. Since #192 that is everything except native libraries — so discovering architectures either sees nothing (a walk) or forces the whole `lib/` directory to be extracted (`get("lib").list()`, ~268 MB on a YouTube build). Two independent junk-cleaner patches use exactly that idiom, including the one from #191 (cc @BlazeFTL).

### Changes

`ResourcePatchContext.listApkEntries(prefix)` reads the archive's central directory, so a patch can enumerate without staging anything:

```kotlin
// discover architectures without materialising lib/
val archs = listApkEntries("lib/").map { it.substringAfter("lib/").substringBefore("/") }.toSet()
```

Names come back as archive names, so they can be passed straight to `get()`. The listing describes the input APK, so it does not reflect files a patch has since added, changed or deleted — this is documented on the API.

### Validation

`./gradlew test` passes, with cases pinning that listing stages nothing to the working directory, that an empty prefix lists every entry, and that returned names round-trip through `get()`.

### Notes

These changes were developed with AI assistance.
