### PR TITLE
feat: Add an optional patch category

### DIFF
--- a/api/morphe-patcher.api
+++ b/api/morphe-patcher.api
@@ -883,12 +883,13 @@ public final class app/morphe/patcher/patch/Options : java/util/Map, kotlin/jvm/
 }
 
 public abstract class app/morphe/patcher/patch/Patch {
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/util/List;Ljava/util/Set;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lapp/morphe/patcher/patch/AvailabilityResolver;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/util/List;Ljava/util/Set;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lapp/morphe/patcher/patch/AvailabilityResolver;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/util/List;Ljava/util/Set;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lapp/morphe/patcher/patch/AvailabilityResolver;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/util/List;Ljava/util/Set;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lapp/morphe/patcher/patch/AvailabilityResolver;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/util/Set;Ljava/util/Set;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun execute (Lapp/morphe/patcher/patch/PatchContext;)V
 	public final fun finalize (Lapp/morphe/patcher/patch/PatchContext;)V
 	public final fun getAvailability ()Lapp/morphe/patcher/patch/AvailabilityResolver;
+	public final fun getCategory ()Ljava/lang/String;
 	public final fun getCompatibility ()Ljava/util/List;
 	public final fun getCompatiblePackages ()Ljava/util/Set;
 	public final fun getDefault ()Z
@@ -917,6 +918,7 @@ public final class app/morphe/patcher/patch/PatchAvailabilityKt {
 public abstract class app/morphe/patcher/patch/PatchBuilder {
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun availability (Lapp/morphe/patcher/patch/AvailabilityResolver;)V
+	public final fun category (Ljava/lang/String;)V
 	public final fun compatibleWith ([Lapp/morphe/patcher/patch/Compatibility;)V
 	public final fun compatibleWith ([Ljava/lang/String;)V
 	public final fun compatibleWith ([Lkotlin/Pair;)V
@@ -924,6 +926,7 @@ public abstract class app/morphe/patcher/patch/PatchBuilder {
 	public final fun execute (Lkotlin/jvm/functions/Function1;)V
 	public final fun finalize (Lkotlin/jvm/functions/Function1;)V
 	protected final fun getAvailability ()Lapp/morphe/patcher/patch/AvailabilityResolver;
+	protected final fun getCategory ()Ljava/lang/String;
 	protected final fun getCompatibility ()Ljava/util/List;
 	protected final fun getCompatiblePackages ()Ljava/util/Set;
 	protected final fun getDefault ()Z
@@ -938,6 +941,7 @@ public abstract class app/morphe/patcher/patch/PatchBuilder {
 	public final fun invoke (Lapp/morphe/patcher/patch/Option;)Lapp/morphe/patcher/patch/Option;
 	public final fun invoke (Ljava/lang/String;[Ljava/lang/String;)Lkotlin/Pair;
 	protected final fun setAvailability (Lapp/morphe/patcher/patch/AvailabilityResolver;)V
+	protected final fun setCategory (Ljava/lang/String;)V
 	protected final fun setCompatibility (Ljava/util/List;)V
 	protected final fun setCompatiblePackages (Ljava/util/Set;)V
 	protected final fun setDependencies (Ljava/util/Set;)V

--- a/src/main/kotlin/app/morphe/patcher/patch/Patch.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/Patch.kt
@@ -40,6 +40,8 @@ typealias Package = Pair<PackageName, Set<VersionName>?>
  * in reverse order of execution.
  * @param availability Optional resolver that decides the patch's [PatchAvailability] for a given
  *   [InstallerType] and [ApkArchitecture]. When null, callers should fall back to [default].
+ * @param category Optional group this patch belongs to, used by callers to section their patch
+ *   list. Free-form, so a bundle picks its own taxonomy. Null leaves the patch ungrouped.
  *
  * @constructor Create a new patch.
  */
@@ -54,10 +56,11 @@ sealed class Patch<C : PatchContext<*>>(
     // Must be internal and nullable, so that Patcher.invoke can check,
     // if a patch has a finalizing block in order to not emit it twice.
     internal var finalizeBlock: ((C) -> Unit)?,
-    // Additive field. Trailing position with a default keeps binary compatibility for existing
+    // Additive fields. Trailing position with a default keeps binary compatibility for existing
     // pre-compiled patch bundles: they call the previous constructor arity, and Kotlin generates
-    // an overload that fills this in as null.
+    // an overload that fills these in as null.
     val availability: AvailabilityResolver? = null,
+    val category: String? = null,
 ) {
 
     @Deprecated("Use constructor with Compatibility object")
@@ -192,6 +195,7 @@ class BytecodePatch internal constructor(
     executeBlock: (BytecodePatchContext) -> Unit,
     finalizeBlock: ((BytecodePatchContext) -> Unit)?,
     availability: AvailabilityResolver? = null,
+    category: String? = null,
 ) : Patch<BytecodePatchContext>(
     name,
     description,
@@ -202,6 +206,7 @@ class BytecodePatch internal constructor(
     executeBlock,
     finalizeBlock,
     availability,
+    category,
 ) {
 
     @Deprecated("Use constructor with extensionInputStreams parameter")
@@ -291,6 +296,7 @@ class RawResourcePatch internal constructor(
     executeBlock: (ResourcePatchContext) -> Unit,
     finalizeBlock: ((ResourcePatchContext) -> Unit)?,
     availability: AvailabilityResolver? = null,
+    category: String? = null,
 ) : Patch<ResourcePatchContext>(
     name,
     description,
@@ -301,6 +307,7 @@ class RawResourcePatch internal constructor(
     executeBlock,
     finalizeBlock,
     availability,
+    category,
 ) {
 
     @Deprecated("Use constructor with Compatibility object")
@@ -358,6 +365,7 @@ class ResourcePatch internal constructor(
     executeBlock: (ResourcePatchContext) -> Unit,
     finalizeBlock: ((ResourcePatchContext) -> Unit)?,
     availability: AvailabilityResolver? = null,
+    category: String? = null,
 ) : Patch<ResourcePatchContext>(
     name,
     description,
@@ -368,6 +376,7 @@ class ResourcePatch internal constructor(
     executeBlock,
     finalizeBlock,
     availability,
+    category,
 ) {
 
     @Deprecated("Use constructor with Compatibility object")
@@ -427,6 +436,7 @@ sealed class PatchBuilder<C : PatchContext<*>>(
     protected var executeBlock: ((C) -> Unit) = { }
     protected var finalizeBlock: ((C) -> Unit)? = null
     protected var availability: AvailabilityResolver? = null
+    protected var category: String? = null
 
     @Deprecated(
         message = "Use 'default' instead of 'use'",
@@ -556,6 +566,18 @@ sealed class PatchBuilder<C : PatchContext<*>>(
         availability = block
     }
 
+    /**
+     * Declare the group this patch belongs to, so callers can section a long patch list.
+     *
+     * The taxonomy belongs to the bundle rather than to the patcher: [name] is free-form and is
+     * matched by callers as an opaque key. Patches that do not call this stay ungrouped.
+     *
+     * @param name The category name, as the user reads it.
+     */
+    fun category(name: String) {
+        category = name
+    }
+
     internal fun resolveDefaultValue(): Boolean {
         return if (name != null && default
             && (compatibility == null || compatibility!!.any { it.packageName == null })
@@ -677,6 +699,7 @@ class BytecodePatchBuilder internal constructor(
         executeBlock = executeBlock,
         finalizeBlock = finalizeBlock,
         availability = availability,
+        category = category,
     )
 }
 
@@ -723,6 +746,7 @@ class RawResourcePatchBuilder internal constructor(
         executeBlock,
         finalizeBlock,
         availability,
+        category,
     )
 }
 
@@ -769,6 +793,7 @@ class ResourcePatchBuilder internal constructor(
         executeBlock,
         finalizeBlock,
         availability,
+        category,
     )
 }
 


### PR DESCRIPTION
## Summary

Adds an optional, bundle-declared **category** to patches and uses it to section the universal patches in the manager's patch lists. A bundle picks its own taxonomy; the manager groups by whatever it finds and leaves everything else exactly as it is today.

Addresses MorpheApp/morphe-manager#929 and MorpheApp/morphe-manager#933

Large bundles are hard to navigate, and universal ones are the worst of it: a bundle written entirely against universal targets can carry several hundred patches with nothing to sort them by. Both issues ask for the same thing: collapsible sections by patch type, with search reaching inside them.

## Scope: universal patches only, for now

The field is free-form and available to every patch, but the manager currently acts on it **only for universal patches**. A category declared on an app specific patch is read and ignored, and those rows keep exactly the list they have today.

That is deliberate. Universal patches are the ones a list drowns in, while patches written for a single app are already narrowed down by that app. Limiting the first step this way means there is almost nothing to walk back if a taxonomy turns out to be wrong: one condition in `buildPatchGroups`, rather than a layout change across every patch list in the app.

## What changes

**`morphe-patcher`**
- `Patch.category: String?`, added as a trailing field with a default, exactly the way `availability` was added.
- `PatchBuilder.category(name)` for the DSL.
- `api/morphe-patcher.api` regenerated.

**`morphe-patches-library`**
- `PatchListGenerator` writes `category` into `patches-list.json`. Purely additive: existing consumers ignore the new field, and it stays `null` for bundles that declare nothing.

**`morphe-patches-template`**
- The template carries its own copy of `PatchListGenerator`, so it gets the same change. Kept identical to the library copy apart from its package, which is how the two have been kept so far.

**`morphe-manager`**
- `PatchInfo.category`, read straight off the loaded patch.
- `PatchesListShared.kt` is generalized from the fixed pair "app specific + universal" into a list of blocks: `PatchGroup`, `buildPatchGroups()`, `patchGroupRows()`. The universal block is now simply the last group, still folded by default, and holds whatever the bundle did not categorize.
- Settings → Appearance → **Patch list → Group by category** (on by default).

## Backwards compatibility

- **Existing bundles keep working untouched.** Bundles call the `bytecodePatch { }` DSL, never the `Patch` constructor, so a bundle compiled before this change simply never calls `category(...)` and the field stays `null`.
- **A bundle that declares no categories renders exactly the list it renders today**: one headerless block plus the universal tail. This is not a special case in the code, it is what `buildPatchGroups` produces when every category is `null`.
- **App specific rows are untouched either way**, since categories are not acted on for them yet.
- **No data migration.** Selections, options, `SeenPatch` and exported configurations are keyed by patch name via `uniqueNames()`. `category` is deliberately not part of that key, so every stored selection stays valid.
- **Users who do not want it** switch the setting off, which collapses the categories back into the plain list.

## Declaring a category

One line in the patch builder. Patches that do not call it stay ungrouped.

```kotlin
val overrideCertificatePinningPatch = resourcePatch(
    name = "Override certificate pinning",
    description = "Overrides certificate pinning, allowing to inspect traffic via a proxy.",
    default = false
) {
    category("Privacy and network")

    execute {
        // ...
    }
}
```

The name is free-form, matched by the manager as an opaque key, so a bundle can ship any taxonomy it likes without agreeing on one with us. Nothing has to be registered anywhere: an unknown category is simply a new section header.

## How it looks in the manager

- Each category is a collapsible header carrying its patch count, and a badge with the number of enabled patches so a folded block never hides a selection silently.
- Categories start expanded; the universal block keeps its current folded default.
- Searching or filtering forces every block open and drops the empty ones, so a match is never hidden behind a fold.
- Ordering: the patches written for the app at hand first (no header, as today), then the declared categories alphabetically, then the universal patches the bundle did not categorize.
- All three patch lists share the same code: the expert mode selection dialog, the per app patch list, and the bundle browser in Patch sources.

<details>
 <summary>Screenshot</summary>

<img width="1080" height="1986" alt="Screenshot_2026-09-05-00-14-55-060_app morphe manager debug-edit" src="https://github.com/user-attachments/assets/7aab821f-4046-4dae-b6d4-9f75bcd6773e" />

</details>

## Merge order

The repositories depend on each other, so merge and release in this order:

1. https://github.com/MorpheApp/morphe-patcher/pull/198
2. https://github.com/MorpheApp/morphe-patches-library/pull/54
3. https://github.com/MorpheApp/morphe-manager/pull/941
4. https://github.com/MorpheApp/morphe-patches-template/pull/60