### PR TITLE
feat: Let delete() exclude unstaged archive entries from the patched APK

### DIFF
--- a/docs/4_apis.md
+++ b/docs/4_apis.md
@@ -57,7 +57,8 @@ execute {
 
 The `delete` function can mark files for deletion when the APK is rebuilt. It accepts decoded
 resource paths as well as any other entry of the APK as returned by `listApkEntries(String)`,
-including native libraries, which are never staged to the working directory.
+including native libraries, which are never staged to the working directory. A directory name
+such as `lib/x86/` deletes everything below it. The manifest and `resources.arsc` cannot be deleted.
 
 ```kt
 execute {

--- a/docs/4_apis.md
+++ b/docs/4_apis.md
@@ -55,11 +55,18 @@ execute {
 }
 ```
 
-The `delete` function can mark files for deletion when the APK is rebuilt.
+The `delete` function can mark files for deletion when the APK is rebuilt. It accepts decoded
+resource paths as well as any other entry of the APK as returned by `listApkEntries(String)`,
+including native libraries, which are never staged to the working directory.
 
 ```kt
 execute {
     delete("res/values/strings.xml")
+
+    // Keep only one architecture.
+    listApkEntries("lib/")
+        .filterNot { it.startsWith("lib/arm64-v8a/") }
+        .forEach(::delete)
 }
 ```
 

--- a/src/main/kotlin/app/morphe/patcher/apk/ApkUtils.kt
+++ b/src/main/kotlin/app/morphe/patcher/apk/ApkUtils.kt
@@ -48,8 +48,9 @@ object ApkUtils {
      *
      * The order of operation is as follows:
      * 1. Use resources.apk compiled by AAPT as the output base, when present.
-     * 2. Write raw resources.
-     * 3. Delete resources staged for deletion.
+     * 2. Delete resources staged for deletion.
+     * 3. Write raw resources. This comes after the deletion so that an entry a patch deleted and
+     *    then recreated ends up with the recreated content rather than removed.
      * 4. Write patched dex files.
      * 5. Realign the APK.
      *
@@ -77,18 +78,19 @@ object ApkUtils {
                     }.forEach(StoredEntry::delete)
                 }
 
+                // Delete resources that were staged for deletion, before adding the raw resources:
+                // everything in otherResources is the newest version of its entry by construction.
+                if (resources.deleteResources.isNotEmpty()) {
+                    targetApkZFile.entries().filter { entry ->
+                        entry.centralDirectoryHeader.name in resources.deleteResources
+                    }.forEach(StoredEntry::delete)
+                }
+
                 // Add resources not compiled by AAPT.
                 resources.otherResources?.let { otherResources ->
                     targetApkZFile.addAllRecursively(otherResources) { file ->
                         file.relativeTo(otherResources).invariantSeparatorsPath !in resources.doNotCompress
                     }
-                }
-
-                // Delete resources that were staged for deletion.
-                if (resources.deleteResources.isNotEmpty()) {
-                    targetApkZFile.entries().filter { entry ->
-                        entry.centralDirectoryHeader.name in resources.deleteResources
-                    }.forEach(StoredEntry::delete)
                 }
             }
 

--- a/src/main/kotlin/app/morphe/patcher/patch/ResourcePatchContext.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/ResourcePatchContext.kt
@@ -116,8 +116,14 @@ class ResourcePatchContext internal constructor(
     /**
      * Mark a file for deletion when the APK is rebuilt.
      *
+     * The name is either a decoded resource path such as `res/drawable/icon.png`, or any other
+     * entry of the APK being patched as returned by [listApkEntries], such as
+     * `lib/x86/libfoo.so` or `assets/data.bin`. Archive entries are excluded from the rebuilt APK
+     * whether or not they were staged to the working directory, so this works for native
+     * libraries too. Deleting a name that exists nowhere is a no-op.
+     *
      * @param name The name of the file to delete.
-     * @param packageName The package name the file exists in. Defaults to the package name of the APK.
+     * @param packageName The package name a decoded resource exists in. Defaults to the package name of the APK.
      */
     @Suppress("unused")
     fun delete(name: String, packageName: String? = null) = resourceCoder.deleteFile(name, packageName)

--- a/src/main/kotlin/app/morphe/patcher/patch/ResourcePatchContext.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/ResourcePatchContext.kt
@@ -120,7 +120,9 @@ class ResourcePatchContext internal constructor(
      * entry of the APK being patched as returned by [listApkEntries], such as
      * `lib/x86/libfoo.so` or `assets/data.bin`. Archive entries are excluded from the rebuilt APK
      * whether or not they were staged to the working directory, so this works for native
-     * libraries too. Deleting a name that exists nowhere is a no-op.
+     * libraries too. A directory name, such as `lib/x86/`, deletes everything below it. Deleting a
+     * name that matches nothing is a no-op. A file deleted and then recreated with [get] keeps the
+     * recreated content. The manifest and `resources.arsc` cannot be deleted.
      *
      * @param name The name of the file to delete.
      * @param packageName The package name a decoded resource exists in. Defaults to the package name of the APK.

--- a/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
@@ -1031,22 +1031,40 @@ internal class ArsclibResourceCoder(
         // file there is enough, the snapshot diff reports it as deleted.
         if (alias == "res" || alias.startsWith("res/") || alias == "package.json") {
             val pkgName = packageName ?: lazyPackageInfo.value.packageName
-            val file = packageDirectories[pkgName]?.resolve(alias)
-                ?: throw PatchException("Package $pkgName not found")
+            val packageDirectory = packageDirectories[pkgName] ?: throw PatchException("Package $pkgName not found")
+            val file = resolveInside(packageDirectory, alias)
+                ?: throw PatchException("Refusing to delete \"$path\": it escapes the working directory")
             Files.deleteIfExists(file.toPath())
             return
         }
 
-        if (alias == "AndroidManifest.xml") throw PatchException("The manifest cannot be deleted")
+        if (alias == "AndroidManifest.xml" || alias == "resources.arsc") {
+            throw PatchException("\"$path\" cannot be deleted")
+        }
 
         // Anything else is an archive entry, as named by listApkEntries. A staged copy is removed,
         // but that alone is not enough: native libraries are never staged, and a copy extracted on
         // demand is not in the decode snapshot, so its removal would only discard the extraction
         // and leave the original entry in the output. Record the entry for exclusion instead, the
         // same way stripped native libraries are.
-        val staged = otherResourcesRootDirectory.resolve(alias)
-        val removedStagedCopy = Files.deleteIfExists(staged.toPath())
+        val staged = resolveInside(otherResourcesRootDirectory, alias)
+            ?: throw PatchException("Refusing to delete \"$path\": it escapes the working directory")
         val archiveName = archiveNameOf(alias)
+
+        // A directory, either named with a trailing slash as archives list them or staged as one,
+        // stands for everything below it.
+        if (alias.endsWith("/") || staged.isDirectory) {
+            val prefix = "${archiveName.trimEnd('/')}/"
+            val removedStagedCopies = staged.exists() && staged.deleteRecursively()
+            val entries = apkEntryNames.filter { it == archiveName || it.startsWith(prefix) }
+            deletedArchiveEntries += entries
+            if (entries.isEmpty() && !removedStagedCopies) {
+                logger.fine { "Nothing to delete for \"$path\": not a decoded resource or an APK entry" }
+            }
+            return
+        }
+
+        val removedStagedCopy = Files.deleteIfExists(staged.toPath())
         if (archiveName in apkEntryNames) {
             deletedArchiveEntries += archiveName
         } else if (!removedStagedCopy) {

--- a/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
@@ -149,6 +149,20 @@ internal class ArsclibResourceCoder(
      */
     private val strippedLibraries = mutableSetOf<String>()
 
+    /**
+     * Archive entries a patch deleted by name through [deleteFile] that are not decoded resources:
+     * native libraries, or root entries a patch discovered with [listApkEntries]. Held apart from
+     * [deletedFiles] for the same reason as [strippedLibraries].
+     */
+    private val deletedArchiveEntries = mutableSetOf<String>()
+
+    /** Entry names of the input APK, read once, since [deleteFile] is often called per entry. */
+    private val apkEntryNames: Set<String> by lazy {
+        ZFile.openReadOnly(apkFile).use { zFile ->
+            zFile.entries().mapTo(HashSet()) { it.centralDirectoryHeader.name }
+        }
+    }
+
     /** Paths that must be stored uncompressed regardless of what the input APK did. */
     private val uncompressedOverrides = mutableSetOf<String>()
     internal var pathMap: PathMap = PathMap.EMPTY
@@ -399,7 +413,7 @@ internal class ArsclibResourceCoder(
             zFile.entries().forEach entries@{ entry ->
                     val name = entry.centralDirectoryHeader.name
                     if (!name.startsWith("$NATIVE_LIBRARY_DIRECTORY/") || name.endsWith("/") ||
-                        name in strippedLibraries) return@entries
+                        name in strippedLibraries || name in deletedArchiveEntries) return@entries
                     // Straight into the staging directory: these only need to reach the output,
                     // no patch is going to read them.
                     val destination = resolveInside(staging, name) ?: return@entries
@@ -539,6 +553,7 @@ internal class ArsclibResourceCoder(
         add("resources.arsc")
         addAll(deletedFiles)
         addAll(strippedLibraries)
+        addAll(deletedArchiveEntries)
         addAll(relocatedRootFiles.values)
 
         modifiedResResources.forEach { file ->
@@ -877,9 +892,9 @@ internal class ArsclibResourceCoder(
                     }
                 }
                 logger.info("Stripped $strippedLibCount lib files")
-            } + deletedFiles + strippedLibraries
+            } + deletedFiles + strippedLibraries + deletedArchiveEntries
         } else {
-            deletedFiles + strippedLibraries
+            deletedFiles + strippedLibraries + deletedArchiveEntries
         }
 
     /**
@@ -1010,10 +1025,33 @@ internal class ArsclibResourceCoder(
     }
 
     override fun deleteFile(path: String, packageName: String?) {
-        val pkgName = packageName ?: lazyPackageInfo.value.packageName
-        val file = packageDirectories[pkgName]?.resolve(path) ?: throw PatchException("Package $pkgName not found")
+        val alias = aliasOf(path)
 
-        Files.deleteIfExists(file.toPath())
+        // Decoded resources are package scoped and live in the working directory; removing the
+        // file there is enough, the snapshot diff reports it as deleted.
+        if (alias == "res" || alias.startsWith("res/") || alias == "package.json") {
+            val pkgName = packageName ?: lazyPackageInfo.value.packageName
+            val file = packageDirectories[pkgName]?.resolve(alias)
+                ?: throw PatchException("Package $pkgName not found")
+            Files.deleteIfExists(file.toPath())
+            return
+        }
+
+        if (alias == "AndroidManifest.xml") throw PatchException("The manifest cannot be deleted")
+
+        // Anything else is an archive entry, as named by listApkEntries. A staged copy is removed,
+        // but that alone is not enough: native libraries are never staged, and a copy extracted on
+        // demand is not in the decode snapshot, so its removal would only discard the extraction
+        // and leave the original entry in the output. Record the entry for exclusion instead, the
+        // same way stripped native libraries are.
+        val staged = otherResourcesRootDirectory.resolve(alias)
+        val removedStagedCopy = Files.deleteIfExists(staged.toPath())
+        val archiveName = archiveNameOf(alias)
+        if (archiveName in apkEntryNames) {
+            deletedArchiveEntries += archiveName
+        } else if (!removedStagedCopy) {
+            logger.fine { "Nothing to delete for \"$path\": not a decoded resource or an APK entry" }
+        }
     }
 
     override fun close() {
@@ -1024,6 +1062,7 @@ internal class ArsclibResourceCoder(
         lazilyExtractedRootFiles.clear()
         relocatedRootFiles.clear()
         strippedLibraries.clear()
+        deletedArchiveEntries.clear()
         uncompressedOverrides.clear()
         fileSnapshotCache = mutableMapOf()
     }

--- a/src/main/kotlin/app/morphe/patcher/resource/coder/ResourceCoder.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/coder/ResourceCoder.kt
@@ -103,10 +103,12 @@ internal interface ResourceCoder : Closeable {
     fun addFile(destPath: String, srcFile: File, packageName: String? = null): File
 
     /**
-     * Delete a file from the working directory. The file will be tracked for deletion in the final resources.apk.
+     * Delete a decoded resource from the working directory, tracked for deletion in the final APK,
+     * or exclude any other archive entry (as named by [listApkEntries]) from the rebuilt APK,
+     * whether or not it was staged to the working directory.
      *
-     * @param path The path of the file to delete, relative to the package directory.
-     * @param packageName The package name of the resources bundle this file should be deleted from. Defaults to the package name of the application. The package name should be the original package name before any patches are applied.
+     * @param path The path of the decoded resource relative to the package directory, or the archive entry name.
+     * @param packageName The package name of the resources bundle a decoded resource should be deleted from. Defaults to the package name of the application. The package name should be the original package name before any patches are applied.
      */
     fun deleteFile(path: String, packageName: String? = null)
 }

--- a/src/test/kotlin/app/morphe/patcher/apk/ApkUtilsTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/apk/ApkUtilsTest.kt
@@ -124,6 +124,27 @@ internal class ApkUtilsTest {
         assertTrue(primaryDex.closed)
     }
 
+    @Test
+    fun `an entry deleted and then recreated keeps the recreated content`() {
+        val targetApk = temporaryDirectory.resolve("target.apk").also { apk ->
+            writeZip(apk, mapOf("assets/data.bin" to "original".toByteArray()))
+        }
+        val otherResources = temporaryDirectory.resolve("other-resources").also { directory ->
+            directory.resolve("assets/data.bin").apply {
+                parentFile.mkdirs()
+                writeText("recreated")
+            }
+        }
+        val result = PatcherResult(
+            emptySet(),
+            PatcherResult.PatchedResources(null, otherResources, emptySet(), setOf("assets/data.bin")),
+        )
+
+        result.applyTo(targetApk)
+
+        assertContentEquals("recreated".toByteArray(), readZip(targetApk)["assets/data.bin"])
+    }
+
     private fun writeZip(file: File, entries: Map<String, ByteArray>) {
         ZipOutputStream(file.outputStream()).use { output ->
             entries.forEach { (name, contents) ->

--- a/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
@@ -2115,4 +2115,39 @@ internal class ArsclibResourceCoderTest {
 
         assertThrows<PatchException> { testCoder.deleteFile("AndroidManifest.xml") }
     }
+
+    @Test
+    fun `deleteFile of a directory entry deletes everything below it without throwing`(@TempDir tempDir: File) {
+        val testCoder = coderWithApk(tempDir, "lib/", "lib/x86/", "lib/x86/liba.so", "lib/x86/libb.so", "lib/arm64-v8a/liba.so")
+        // A staged, non-empty directory used to make deleteIfExists throw DirectoryNotEmptyException.
+        val extracted = testCoder.getFile("lib/x86/liba.so", null, copy = true)
+        assertTrue(extracted.isFile)
+
+        assertDoesNotThrow { testCoder.deleteFile("lib/x86/") }
+
+        assertFalse(extracted.parentFile.exists())
+        val deleted = testCoder.getDeletedFiles(ResourceMode.FULL)
+        assertTrue(setOf("lib/x86/", "lib/x86/liba.so", "lib/x86/libb.so").all { it in deleted })
+        assertFalse("lib/arm64-v8a/liba.so" in deleted)
+        assertFalse("lib/" in deleted)
+    }
+
+    @Test
+    fun `deleteFile refuses names escaping the working directory`(@TempDir tempDir: File) {
+        val testCoder = coderWithApk(tempDir, "assets/keep.bin")
+        val outside = tempDir.resolve("outside.txt").apply { writeText("keep me") }
+
+        assertThrows<PatchException> { testCoder.deleteFile("../../outside.txt") }
+        assertThrows<PatchException> { testCoder.deleteFile(outside.absolutePath) }
+
+        assertTrue(outside.exists())
+        assertTrue(testCoder.getDeletedFiles(ResourceMode.FULL).isEmpty())
+    }
+
+    @Test
+    fun `deleteFile refuses the resource table`(@TempDir tempDir: File) {
+        val testCoder = coderWithApk(tempDir, "resources.arsc")
+
+        assertThrows<PatchException> { testCoder.deleteFile("resources.arsc") }
+    }
 }

--- a/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
@@ -30,6 +30,9 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import app.morphe.patcher.patch.PatchException
 
 internal class ArsclibResourceCoderTest {
 
@@ -2034,4 +2037,82 @@ internal class ArsclibResourceCoderTest {
         assertFalse("classes.dex" in uncompressed, "non-listed file should be compressed in $mode")
     }
 
+
+    // ==================== deleteFile tests ====================
+
+    private fun coderWithApk(tempDir: File, vararg entries: String): ArsclibResourceCoder {
+        val apk = tempDir.resolve("input.apk")
+        ZFile.openReadWrite(apk).use { zip ->
+            entries.forEach { zip.add(it, ByteArrayInputStream("data of $it".toByteArray())) }
+        }
+        return ArsclibResourceCoder(tempDir.resolve("working").apply { mkdirs() }, apk)
+    }
+
+    @Test
+    fun `deleteFile excludes an unstaged archive entry from the rebuilt APK`(@TempDir tempDir: File) {
+        val testCoder = coderWithApk(tempDir, "lib/x86/libfoo.so", "lib/arm64-v8a/libfoo.so")
+
+        testCoder.deleteFile("lib/x86/libfoo.so")
+
+        assertTrue("lib/x86/libfoo.so" in testCoder.getDeletedFiles(ResourceMode.FULL))
+        assertFalse("lib/arm64-v8a/libfoo.so" in testCoder.getDeletedFiles(ResourceMode.FULL))
+        assertTrue("lib/x86/libfoo.so" in testCoder.changedArchiveEntries(packageRenamed = false))
+        assertTrue("lib/x86/libfoo.so" in testCoder.getDeletedFiles(ResourceMode.NONE))
+    }
+
+    @Test
+    fun `deleteFile removes an extracted copy and still excludes the entry`(@TempDir tempDir: File) {
+        val testCoder = coderWithApk(tempDir, "lib/x86/libfoo.so")
+        val extracted = testCoder.getFile("lib/x86/libfoo.so", null, copy = true)
+        assertTrue(extracted.isFile)
+
+        testCoder.deleteFile("lib/x86/libfoo.so")
+
+        assertFalse(extracted.exists())
+        assertTrue("lib/x86/libfoo.so" in testCoder.getDeletedFiles(ResourceMode.FULL))
+    }
+
+    @Test
+    fun `deleteFile is not fooled by the reuse pass`(@TempDir tempDir: File) {
+        val testCoder = coderWithApk(tempDir, "lib/x86/libfoo.so", "lib/arm64-v8a/libfoo.so")
+        testCoder.deleteFile("lib/x86/libfoo.so")
+
+        ApkModule.loadApkFile(tempDir.resolve("input.apk")).use { originalModule ->
+            ApkModule().use { encoded ->
+                testCoder.reuseUnchangedArchiveEntries(
+                    originalModule,
+                    encoded,
+                    testCoder.changedArchiveEntries(packageRenamed = false),
+                )
+                assertFalse(encoded.zipEntryMap.contains("lib/x86/libfoo.so"))
+                assertTrue(encoded.zipEntryMap.contains("lib/arm64-v8a/libfoo.so"))
+            }
+        }
+    }
+
+    @Test
+    fun `deleteFile of a name that exists nowhere is a no-op`(@TempDir tempDir: File) {
+        val testCoder = coderWithApk(tempDir, "assets/keep.bin")
+
+        assertDoesNotThrow { testCoder.deleteFile("assets/missing.bin") }
+
+        assertTrue(testCoder.getDeletedFiles(ResourceMode.FULL).isEmpty())
+    }
+
+    @Test
+    fun `deleteFile still removes decoded resources from the package directory`() {
+        val pkgDir = setupPackageDir()
+        val file = pkgDir.resolve("res/values/strings.xml").apply { parentFile.mkdirs(); writeText("<resources/>") }
+
+        coder.deleteFile("res/values/strings.xml", "com.test.app")
+
+        assertFalse(file.exists())
+    }
+
+    @Test
+    fun `deleteFile refuses the manifest`(@TempDir tempDir: File) {
+        val testCoder = coderWithApk(tempDir, "AndroidManifest.xml")
+
+        assertThrows<PatchException> { testCoder.deleteFile("AndroidManifest.xml") }
+    }
 }


### PR DESCRIPTION
Closes #195.

Native libraries are never staged to the working directory, and other root entries a patch requests via `get()` are extracted on demand and are not part of the decode snapshot. Deleting such a copy only discarded the extraction and left the original entry in the output, so per-patch architecture stripping silently did nothing after the staging changes.

`delete()` now accepts any entry name of the input APK, as returned by `listApkEntries()`. Decoded resources are removed from the working directory as before; any other name removes a staged or extracted copy and records the entry for exclusion, honoured by `applyTo` and the archive reuse pass the same way stripped native libraries already are. A directory name deletes everything below it. Names that match nothing stay a no-op; names escaping the working directory, the manifest and `resources.arsc` are refused.

`applyTo` now deletes before adding raw resources, so an entry a patch deletes and then recreates keeps the recreated content (this also covers stripped native libraries a patch re-adds).

Docs updated in `docs/4_apis.md`.

Verified on an AVD with a patch that keeps only `lib/arm64-v8a/`: the other architectures are removed on this branch and remain in place on `dev`.
