### PR TITLE
fix: Keep the input DEX files when no bytecode was patched

### DIFF
--- a/src/main/kotlin/app/morphe/patcher/apk/ApkUtils.kt
+++ b/src/main/kotlin/app/morphe/patcher/apk/ApkUtils.kt
@@ -70,9 +70,11 @@ object ApkUtils {
 
         ZFile.openReadWrite(apkFile, zFileOptions).use { targetApkZFile ->
             resources.let { resources ->
-                // A compiled resource APK is a complete non-DEX APK. Remove any accidentally packaged DEX files
-                // before adding the final patched DEX set.
-                if (resources.resourcesApk != null) {
+                // A compiled resource APK carries the input's DEX files as unchanged root entries. When
+                // there is a patched DEX set, remove them first so no stale DEX file survives beside it.
+                // Without bytecode patching (BytecodeMode.NONE) the set is empty and the input's DEX
+                // files are the output, so they must stay.
+                if (resources.resourcesApk != null && dexFiles.isNotEmpty()) {
                     targetApkZFile.entries().filter { entry ->
                         entry.centralDirectoryHeader.name.matches(dexEntryName)
                     }.forEach(StoredEntry::delete)

--- a/src/test/kotlin/app/morphe/patcher/apk/ApkUtilsTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/apk/ApkUtilsTest.kt
@@ -145,6 +145,32 @@ internal class ApkUtilsTest {
         assertContentEquals("recreated".toByteArray(), readZip(targetApk)["assets/data.bin"])
     }
 
+    @Test
+    fun `input dex files survive when no bytecode was patched`() {
+        val resourcesApk = temporaryDirectory.resolve("resources.apk").also { apk ->
+            writeZip(
+                apk,
+                mapOf(
+                    "resources.arsc" to "table".toByteArray(),
+                    "classes.dex" to "original dex".toByteArray(),
+                    "classes2.dex" to "original dex 2".toByteArray(),
+                ),
+            )
+        }
+        val targetApk = temporaryDirectory.resolve("target.apk")
+        val result = PatcherResult(
+            emptySet(),
+            PatcherResult.PatchedResources(resourcesApk, null, emptySet(), emptySet()),
+        )
+
+        result.applyTo(targetApk)
+
+        val entries = readZip(targetApk)
+        assertContentEquals("original dex".toByteArray(), entries["classes.dex"])
+        assertContentEquals("original dex 2".toByteArray(), entries["classes2.dex"])
+        assertContentEquals("table".toByteArray(), entries["resources.arsc"])
+    }
+
     private fun writeZip(file: File, entries: Map<String, ByteArray>) {
         ZipOutputStream(file.outputStream()).use { output ->
             entries.forEach { (name, contents) ->


### PR DESCRIPTION
Since the compiled resource APK became the output base (#169), `applyTo` removed every DEX entry from it before adding the patched DEX set. Those entries are the input's `classes*.dex`, staged as root entries since #192 and reused unchanged. With only resource patches selected the bytecode mode is `NONE` and the patched set is empty, so the output APK had no `classes*.dex` at all.

Reported in #195 (BlazeFTL's `DrawableCleanPatch` / `LangCleanPatch` selected alone).

Remove the input DEX files only when there is a patched set to replace them; with no bytecode patching they are the output. Adds a test for the resource-only case.
