### PR TITLE
fix: Carry the input DEX files into the compiled resource APK

### DIFF
--- a/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
@@ -75,6 +75,7 @@ private const val PATCHED_ROOT_DIRECTORY = "patched-root"
 
 /** The one archive directory left unstaged, because it dominates the APK's size. */
 private const val NATIVE_LIBRARY_DIRECTORY = "lib"
+private val DEX_ENTRY_NAME = Regex("classes\\d*\\.dex")
 
 internal class ArsclibResourceCoder(
     internal val workingDir: File,
@@ -945,12 +946,16 @@ internal class ArsclibResourceCoder(
 
     /**
      * Whether a root entry is staged to the working directory during decode. Everything is,
-     * except native libraries: they are the bulk of an APK, and nothing enumerates them on disk.
+     * except native libraries and DEX files. Native libraries are the bulk of an APK, and nothing
+     * enumerates them on disk. DEX files are never written by the decoder either (the DEX decoder
+     * is a no-op) and are handled by the bytecode side; declaring them unstaged here lets
+     * [reuseUnchangedArchiveEntries] carry them into the compiled resource APK, which is what the
+     * output is built from, so they survive when no bytecode was patched.
      * Staging the rest matters because a patch that discovers files by walking the directory can
      * only see what is on disk, and the on-demand extraction in [getFile] cannot serve a walk.
      */
     internal fun stagesRootEntry(alias: String) =
-        !alias.startsWith("$NATIVE_LIBRARY_DIRECTORY/")
+        !alias.startsWith("$NATIVE_LIBRARY_DIRECTORY/") && !DEX_ENTRY_NAME.matches(alias)
 
     /**
      * Extract a single root entry from the input APK into the working directory, and record it

--- a/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoderTest.kt
@@ -421,7 +421,7 @@ internal class ArsclibResourceCoderTest {
     }
 
     @Test
-    fun `reuseUnchangedArchiveEntries retains omitted root entries but not deleted files or dex`(
+    fun `reuseUnchangedArchiveEntries retains omitted root entries and dex but not deleted files`(
         @TempDir tempDir: File,
     ) {
         val originalApk = tempDir.resolve("original.apk")
@@ -446,15 +446,17 @@ internal class ArsclibResourceCoderTest {
 
         ApkModule.loadApkFile(originalApk).use { original ->
             ApkModule().use { encoded ->
+                // Unstaged lib, staged-and-unchanged asset, and the input DEX (never staged; the
+                // bytecode side replaces it in applyTo when it produced a patched set).
                 assertEquals(
-                    2,
+                    3,
                     testCoder.reuseUnchangedArchiveEntries(original, encoded, testCoder.changedArchiveEntries(false)),
                 )
                 val output = tempDir.resolve("output.apk")
                 encoded.writeApk(output)
                 ZipFile(output).use { zip ->
                     assertEquals(
-                        setOf("lib/arm64-v8a/keep.so", "assets/keep.txt"),
+                        setOf("lib/arm64-v8a/keep.so", "assets/keep.txt", "classes.dex"),
                         zip.entries().asSequence().map { it.name }.toSet(),
                     )
                     assertEquals(
@@ -2168,5 +2170,29 @@ internal class ArsclibResourceCoderTest {
         val testCoder = coderWithApk(tempDir, "resources.arsc")
 
         assertThrows<PatchException> { testCoder.deleteFile("resources.arsc") }
+    }
+
+    @Test
+    fun `reuse carries the input dex files into the compiled resource APK`(@TempDir tempDir: File) {
+        val originalApk = tempDir.resolve("original.apk")
+        ZFile.openReadWrite(originalApk).use { zip ->
+            zip.add("classes.dex", ByteArrayInputStream("dex".toByteArray()))
+            zip.add("classes2.dex", ByteArrayInputStream("dex 2".toByteArray()))
+            zip.add("lib/x86/libfoo.so", ByteArrayInputStream("so".toByteArray()))
+        }
+        val testCoder = ArsclibResourceCoder(tempDir.resolve("working").apply { mkdirs() }, originalApk)
+        assertFalse(testCoder.stagesRootEntry("classes.dex"))
+        assertFalse(testCoder.stagesRootEntry("classes2.dex"))
+        assertTrue(testCoder.stagesRootEntry("assets/classes.dex.txt"))
+
+        ApkModule.loadApkFile(originalApk).use { originalModule ->
+            ApkModule().use { encoded ->
+                // Nothing staged, nothing in the snapshot: exactly the state after a resource-only decode.
+                val reused = testCoder.reuseUnchangedArchiveEntries(originalModule, encoded, emptySet())
+                assertEquals(3, reused)
+                assertTrue(encoded.zipEntryMap.contains("classes.dex"))
+                assertTrue(encoded.zipEntryMap.contains("classes2.dex"))
+            }
+        }
     }
 }


### PR DESCRIPTION
#201 kept the DEX entries of the compiled resource APK when no bytecode was patched, but that APK never contained them: the decoder's DEX handler is a no-op, so `classes*.dex` are never staged, and the archive reuse pass only carried unstaged entries for native libraries. A resource-only run in FULL resource mode therefore still produced an APK without any `classes*.dex` (reported again in #201's comments and #202).

Treat DEX entries as unstaged root entries so the reuse pass copies them into the compiled resource APK unchanged. With a patched DEX set, `applyTo` removes and replaces them as before; without one they are the output.

Verified with the desktop CLI: a single resource patch now yields the input's DEX files instead of none, and a full default bytecode patch set produces a DEX list identical to the unfixed build. Adapts the reuse test that asserted DEX entries are skipped.
