### PR TITLE
feat: Add resource ids and `resourceLiteral` instruction filter

### DIFF
--- a/api/morphe-patcher.api
+++ b/api/morphe-patcher.api
@@ -156,8 +156,8 @@ public final class app/morphe/patcher/InstructionFilterKt {
 	public static synthetic fun newInstance$default (Lkotlin/jvm/functions/Function0;Lapp/morphe/patcher/StringComparisonType;Lapp/morphe/patcher/InstructionLocation;ILjava/lang/Object;)Lapp/morphe/patcher/NewInstanceFilter;
 	public static final fun opcode (Lcom/android/tools/smali/dexlib2/Opcode;Lapp/morphe/patcher/InstructionLocation;)Lapp/morphe/patcher/OpcodeFilter;
 	public static synthetic fun opcode$default (Lcom/android/tools/smali/dexlib2/Opcode;Lapp/morphe/patcher/InstructionLocation;ILjava/lang/Object;)Lapp/morphe/patcher/OpcodeFilter;
-	public static final fun resourceLiteral (Lapp/morphe/patcher/resource/ResourceType;Ljava/lang/String;ZLjava/util/List;Lapp/morphe/patcher/InstructionLocation;)Lapp/morphe/patcher/LiteralFilter;
-	public static synthetic fun resourceLiteral$default (Lapp/morphe/patcher/resource/ResourceType;Ljava/lang/String;ZLjava/util/List;Lapp/morphe/patcher/InstructionLocation;ILjava/lang/Object;)Lapp/morphe/patcher/LiteralFilter;
+	public static final fun resourceLiteral (Lapp/morphe/patcher/resource/ResourceType;Ljava/lang/String;ZLapp/morphe/patcher/InstructionLocation;)Lapp/morphe/patcher/LiteralFilter;
+	public static synthetic fun resourceLiteral$default (Lapp/morphe/patcher/resource/ResourceType;Ljava/lang/String;ZLapp/morphe/patcher/InstructionLocation;ILjava/lang/Object;)Lapp/morphe/patcher/LiteralFilter;
 	public static final fun string (Ljava/lang/String;Lapp/morphe/patcher/InstructionLocation;)Lapp/morphe/patcher/StringFilter;
 	public static final fun string (Ljava/lang/String;Lapp/morphe/patcher/StringComparisonType;Lapp/morphe/patcher/InstructionLocation;)Lapp/morphe/patcher/StringFilter;
 	public static final fun string (Lkotlin/jvm/functions/Function0;Lapp/morphe/patcher/InstructionLocation;)Lapp/morphe/patcher/StringFilter;

--- a/api/morphe-patcher.api
+++ b/api/morphe-patcher.api
@@ -156,6 +156,8 @@ public final class app/morphe/patcher/InstructionFilterKt {
 	public static synthetic fun newInstance$default (Lkotlin/jvm/functions/Function0;Lapp/morphe/patcher/StringComparisonType;Lapp/morphe/patcher/InstructionLocation;ILjava/lang/Object;)Lapp/morphe/patcher/NewInstanceFilter;
 	public static final fun opcode (Lcom/android/tools/smali/dexlib2/Opcode;Lapp/morphe/patcher/InstructionLocation;)Lapp/morphe/patcher/OpcodeFilter;
 	public static synthetic fun opcode$default (Lcom/android/tools/smali/dexlib2/Opcode;Lapp/morphe/patcher/InstructionLocation;ILjava/lang/Object;)Lapp/morphe/patcher/OpcodeFilter;
+	public static final fun resourceLiteral (Lapp/morphe/patcher/resource/ResourceType;Ljava/lang/String;ZLjava/util/List;Lapp/morphe/patcher/InstructionLocation;)Lapp/morphe/patcher/LiteralFilter;
+	public static synthetic fun resourceLiteral$default (Lapp/morphe/patcher/resource/ResourceType;Ljava/lang/String;ZLjava/util/List;Lapp/morphe/patcher/InstructionLocation;ILjava/lang/Object;)Lapp/morphe/patcher/LiteralFilter;
 	public static final fun string (Ljava/lang/String;Lapp/morphe/patcher/InstructionLocation;)Lapp/morphe/patcher/StringFilter;
 	public static final fun string (Ljava/lang/String;Lapp/morphe/patcher/StringComparisonType;Lapp/morphe/patcher/InstructionLocation;)Lapp/morphe/patcher/StringFilter;
 	public static final fun string (Lkotlin/jvm/functions/Function0;Lapp/morphe/patcher/InstructionLocation;)Lapp/morphe/patcher/StringFilter;
@@ -1068,6 +1070,7 @@ public final class app/morphe/patcher/patch/ResourcePatchContext : app/morphe/pa
 	public static synthetic fun get$default (Lapp/morphe/patcher/patch/ResourcePatchContext;Ljava/lang/String;ZILjava/lang/Object;)Ljava/io/File;
 	public fun getFileWorkspace ()Ljava/io/File;
 	public final fun getPackageMetadata ()Lapp/morphe/patcher/PackageMetadata;
+	public final fun getResourceIds ()Lapp/morphe/patcher/resource/ResourceIds;
 	public final fun listApkEntries (Ljava/lang/String;)Ljava/util/List;
 	public static synthetic fun listApkEntries$default (Lapp/morphe/patcher/patch/ResourcePatchContext;Ljava/lang/String;ILjava/lang/Object;)Ljava/util/List;
 }
@@ -1140,6 +1143,17 @@ public final class app/morphe/patcher/resource/PublicXmlManager : java/io/Closea
 	public final fun idExists (Ljava/lang/String;Ljava/lang/String;)Z
 }
 
+public final class app/morphe/patcher/resource/ResourceIds {
+	public final fun get (Lapp/morphe/patcher/resource/ResourceType;Ljava/lang/String;)J
+	public final fun getOrNull (Lapp/morphe/patcher/resource/ResourceType;Ljava/lang/String;)Ljava/lang/Long;
+	public final fun has (Lapp/morphe/patcher/resource/ResourceType;Ljava/lang/String;)Z
+}
+
+public final class app/morphe/patcher/resource/ResourceIdsKt {
+	public static final fun hasResourceId (Lapp/morphe/patcher/resource/ResourceType;Ljava/lang/String;)Z
+	public static final fun resourceId (Lapp/morphe/patcher/resource/ResourceType;Ljava/lang/String;)J
+}
+
 public final class app/morphe/patcher/resource/ResourceMode : java/lang/Enum {
 	public static final field FULL Lapp/morphe/patcher/resource/ResourceMode;
 	public static final field NONE Lapp/morphe/patcher/resource/ResourceMode;
@@ -1147,6 +1161,44 @@ public final class app/morphe/patcher/resource/ResourceMode : java/lang/Enum {
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lapp/morphe/patcher/resource/ResourceMode;
 	public static fun values ()[Lapp/morphe/patcher/resource/ResourceMode;
+}
+
+public final class app/morphe/patcher/resource/ResourceType : java/lang/Enum {
+	public static final field ANIM Lapp/morphe/patcher/resource/ResourceType;
+	public static final field ANIMATOR Lapp/morphe/patcher/resource/ResourceType;
+	public static final field ARRAY Lapp/morphe/patcher/resource/ResourceType;
+	public static final field ATTR Lapp/morphe/patcher/resource/ResourceType;
+	public static final field BOOL Lapp/morphe/patcher/resource/ResourceType;
+	public static final field COLOR Lapp/morphe/patcher/resource/ResourceType;
+	public static final field Companion Lapp/morphe/patcher/resource/ResourceType$Companion;
+	public static final field DIMEN Lapp/morphe/patcher/resource/ResourceType;
+	public static final field DRAWABLE Lapp/morphe/patcher/resource/ResourceType;
+	public static final field FONT Lapp/morphe/patcher/resource/ResourceType;
+	public static final field FRACTION Lapp/morphe/patcher/resource/ResourceType;
+	public static final field ID Lapp/morphe/patcher/resource/ResourceType;
+	public static final field INTEGER Lapp/morphe/patcher/resource/ResourceType;
+	public static final field INTERPOLATOR Lapp/morphe/patcher/resource/ResourceType;
+	public static final field LAYOUT Lapp/morphe/patcher/resource/ResourceType;
+	public static final field MENU Lapp/morphe/patcher/resource/ResourceType;
+	public static final field MIPMAP Lapp/morphe/patcher/resource/ResourceType;
+	public static final field NAVIGATION Lapp/morphe/patcher/resource/ResourceType;
+	public static final field PLURALS Lapp/morphe/patcher/resource/ResourceType;
+	public static final field RAW Lapp/morphe/patcher/resource/ResourceType;
+	public static final field STRING Lapp/morphe/patcher/resource/ResourceType;
+	public static final field STYLE Lapp/morphe/patcher/resource/ResourceType;
+	public static final field STYLEABLE Lapp/morphe/patcher/resource/ResourceType;
+	public static final field TRANSITION Lapp/morphe/patcher/resource/ResourceType;
+	public static final field VALUES Lapp/morphe/patcher/resource/ResourceType;
+	public static final field XML Lapp/morphe/patcher/resource/ResourceType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lapp/morphe/patcher/resource/ResourceType;
+	public static fun values ()[Lapp/morphe/patcher/resource/ResourceType;
+}
+
+public final class app/morphe/patcher/resource/ResourceType$Companion {
+	public final fun fromValue (Ljava/lang/String;)Lapp/morphe/patcher/resource/ResourceType;
+	public final fun fromValueOrNull (Ljava/lang/String;)Lapp/morphe/patcher/resource/ResourceType;
 }
 
 public final class app/morphe/patcher/resource/XmlPullParserUtilsKt {

--- a/docs/2_2_1_fingerprinting.md
+++ b/docs/2_2_1_fingerprinting.md
@@ -61,6 +61,23 @@ object AdLoaderFingerprint : Fingerprint(
 )
 ```
 
+### 📦 Resource ids as literals
+
+Apps refer to their resources by id, and those ids differ per build. `resourceLiteral(type, name)`
+matches an instruction loading the id of a named resource of the APK being patched, looked up
+from its resource table when the fingerprint is first matched:
+
+```kt
+filters = listOf(
+    resourceLiteral(ResourceType.LAYOUT, "account_compact_link"),
+    opcode(Opcode.MOVE_RESULT_OBJECT, InstructionLocation.MatchAfterWithin(5)),
+)
+```
+
+Pass `exceptionIfResourceNotFound = false` for a resource that only some app versions have,
+typically inside `anyInstruction(...)`; the filter then never matches instead of failing. The
+same lookup is available directly with `resourceId(type, name)` and `hasResourceId(type, name)`.
+
 ## 🔎 Example target app in Java and Smali
 
 ```java

--- a/src/main/kotlin/app/morphe/patcher/Fingerprint.kt
+++ b/src/main/kotlin/app/morphe/patcher/Fingerprint.kt
@@ -694,7 +694,8 @@ open class Fingerprint private constructor(
 
     context(patchContext: BytecodePatchContext)
     private fun InstructionFilter.indexedCandidatesOrNull(): Set<PatchClasses.ClassDefWrapper>? = when (this) {
-        is LiteralFilter -> patchContext.patchClasses.getClassesContainingLiteral(literalValue).orEmpty().toSet()
+        // A literal that does not exist in this app cannot match anywhere.
+        is LiteralFilter -> literalValue?.let { patchContext.patchClasses.getClassesContainingLiteral(it) }.orEmpty().toSet()
         else -> exactReferencedTypesOrNull()?.flatMap { type ->
             patchContext.patchClasses.getClassesReferencingType(type).orEmpty()
         }?.toSet()

--- a/src/main/kotlin/app/morphe/patcher/InstructionFilter.kt
+++ b/src/main/kotlin/app/morphe/patcher/InstructionFilter.kt
@@ -453,29 +453,24 @@ fun literal(
 
 /**
  * Literal equal to the id of a resource of the APK being patched, such as a layout or view id.
- * The id is looked up when the fingerprint is first matched, from the APK's resource table, so
- * it is available whether or not resources are decoded. Declared this way the patcher can use
- * its literal index to find candidate classes instead of scanning every class.
  *
  * @param type The resource type.
  * @param name The resource name.
  * @param exceptionIfResourceNotFound If `false` and the APK has no such resource, the filter
- *                                    never matches instead of failing. Useful with [anyInstruction]
- *                                    when a resource exists only in some app versions.
- * @param opcodes Opcodes to match. By default this matches any literal number opcode.
+ *                                    never matches instead of failing. Intended only for use with
+ *                                    [anyInstruction] when a resource exists only in some app versions.
  * @param location Where this filter is allowed to match. Default is anywhere after the previous instruction.
  */
 fun resourceLiteral(
     type: ResourceType,
     name: String,
     exceptionIfResourceNotFound: Boolean = true,
-    opcodes: List<Opcode>? = null,
     location: InstructionLocation = InstructionLocation.MatchAfterAnywhere()
 ) = LiteralFilter(
     {
         if (exceptionIfResourceNotFound || hasResourceId(type, name)) resourceId(type, name) else null
     },
-    opcodes,
+    null,
     location,
 )
 
@@ -523,7 +518,7 @@ class MethodCallFilter internal constructor(
             // up to the root class since class defs are mere Strings.
             if (definingClassLocal == "this") {
                 if (referenceClass != enclosingMethod.definingClass) {
-                    return false;
+                    return false
                 }
             } else if (!definingClassComparison.compare(referenceClass, definingClassLocal)) {
                 return false
@@ -778,7 +773,7 @@ class FieldAccessFilter internal constructor(
 
             if (definingClassLocal == "this") {
                 if (referenceClass != enclosingMethod.definingClass) {
-                    return false;
+                    return false
                 }
             } else if (!definingClassComparison.compare(referenceClass, definingClassLocal)) {
                 return false
@@ -897,7 +892,8 @@ fun fieldAccess(
  * `iget-object v0, p0, Lahhh;->g:Landroid/view/View;`
  *
  * @param reference Exact reference to match.
- * @param opcode Single opcode to match.
+ * @param opcodes List of all possible opcodes to match. Defaults to matching all get/put opcodes.
+ *                (`Opcode.IGET`, `Opcode.SGET`, `Opcode.IPUT`, `Opcode.SPUT`, etc).
  * @param location Where this filter is allowed to match. Default is anywhere after the previous instruction.
  */
 fun fieldAccess(

--- a/src/main/kotlin/app/morphe/patcher/InstructionFilter.kt
+++ b/src/main/kotlin/app/morphe/patcher/InstructionFilter.kt
@@ -2,6 +2,10 @@
 
 package app.morphe.patcher
 
+import app.morphe.patcher.resource.ResourceType
+import app.morphe.patcher.resource.hasResourceId
+import app.morphe.patcher.resource.resourceId
+
 import app.morphe.patcher.FieldAccessFilter.Companion.parseJvmFieldAccess
 import app.morphe.patcher.MethodCallFilter.Companion.parseJvmMethodCall
 import com.android.tools.smali.dexlib2.Opcode
@@ -340,15 +344,23 @@ open class OpcodesFilter protected constructor(
 
 
 class LiteralFilter internal constructor(
-    val literal: () -> Long,
+    literalOrNull: () -> Long?,
     opcodes: List<Opcode>? = null,
     location: InstructionLocation
 ) : OpcodesFilter(opcodes, location) {
 
     /**
      * Store the lambda value instead of calling it more than once.
+     * `null` means the literal does not exist in this app, and the filter never matches.
      */
-    internal val literalValue: Long by lazy(literal)
+    internal val literalValue: Long? by lazy(literalOrNull)
+
+    /**
+     * The literal this filter matches.
+     *
+     * @throws IllegalStateException If the literal does not exist in this app.
+     */
+    val literal: () -> Long = { literalValue ?: error("Literal does not exist in this app") }
 
     override fun matches(
         enclosingMethod: Method,
@@ -429,10 +441,38 @@ fun literal(
  * @param location Where this filter is allowed to match. Default is anywhere after the previous instruction.
  */
 fun literal(
-    literal: () -> Long,
+    literal: () -> Long?,
     opcodes: List<Opcode>? = null,
     location: InstructionLocation = InstructionLocation.MatchAfterAnywhere()
 ) = LiteralFilter(literal, opcodes, location)
+
+/**
+ * Literal equal to the id of a resource of the APK being patched, such as a layout or view id.
+ * The id is looked up when the fingerprint is first matched, from the APK's resource table, so
+ * it is available whether or not resources are decoded. Declared this way the patcher can use
+ * its literal index to find candidate classes instead of scanning every class.
+ *
+ * @param type The resource type.
+ * @param name The resource name.
+ * @param exceptionIfResourceNotFound If `false` and the APK has no such resource, the filter
+ *                                    never matches instead of failing. Useful with [anyInstruction]
+ *                                    when a resource exists only in some app versions.
+ * @param opcodes Opcodes to match. By default this matches any literal number opcode.
+ * @param location Where this filter is allowed to match. Default is anywhere after the previous instruction.
+ */
+fun resourceLiteral(
+    type: ResourceType,
+    name: String,
+    exceptionIfResourceNotFound: Boolean = true,
+    opcodes: List<Opcode>? = null,
+    location: InstructionLocation = InstructionLocation.MatchAfterAnywhere()
+) = LiteralFilter(
+    {
+        if (exceptionIfResourceNotFound || hasResourceId(type, name)) resourceId(type, name) else null
+    },
+    opcodes,
+    location,
+)
 
 
 

--- a/src/main/kotlin/app/morphe/patcher/InstructionFilter.kt
+++ b/src/main/kotlin/app/morphe/patcher/InstructionFilter.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patcher
+ */
+
 @file:Suppress("unused")
 
 package app.morphe.patcher

--- a/src/main/kotlin/app/morphe/patcher/StringComparisonType.kt
+++ b/src/main/kotlin/app/morphe/patcher/StringComparisonType.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patcher
+ */
+
 package app.morphe.patcher
 
 /**

--- a/src/main/kotlin/app/morphe/patcher/extensions/InstructionExtensions.kt
+++ b/src/main/kotlin/app/morphe/patcher/extensions/InstructionExtensions.kt
@@ -2,9 +2,10 @@
  * Copyright 2026 Morphe.
  * https://github.com/MorpheApp/morphe-patcher
  *
- * Continuation of: https://github.com/LisoUseInAIKyrios/revanced-patcher/tree/feat/instruction_filters
- * and a hard fork of: https://github.com/ReVanced/revanced-patcher
+ * Original forked code:
+ * https://github.com/LisoUseInAIKyrios/revanced-patcher
  */
+
 package app.morphe.patcher.extensions
 
 import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod

--- a/src/main/kotlin/app/morphe/patcher/patch/ResourcePatchContext.kt
+++ b/src/main/kotlin/app/morphe/patcher/patch/ResourcePatchContext.kt
@@ -12,6 +12,7 @@ import app.morphe.patcher.InternalApi
 import app.morphe.patcher.PackageMetadata
 import app.morphe.patcher.PatcherConfig
 import app.morphe.patcher.PatcherResult
+import app.morphe.patcher.resource.ResourceIds
 import app.morphe.patcher.resource.ResourceMode
 import app.morphe.patcher.resource.coder.ArsclibResourceCoder
 import app.morphe.patcher.resource.coder.ResourceCoder
@@ -32,6 +33,13 @@ class ResourcePatchContext internal constructor(
     override val fileWorkspace = config.fileWorkspace
 
     private val resourceCoder: ResourceCoder = ArsclibResourceCoder(config.apkFiles, config.apkFile, config.keepArchitectures)
+
+    /**
+     * The resource ids of the APK being patched, read from its resource table on first use.
+     * Also reachable without a context through [app.morphe.patcher.resource.resourceId] and
+     * [app.morphe.patcher.resource.hasResourceId], which is what [app.morphe.patcher.resourceLiteral] uses.
+     */
+    val resourceIds: ResourceIds = ResourceIds { resourceCoder.resourceIds() }.also { ResourceIds.current = it }
 
     val packageMetadata = resourceCoder.getPackageMetadata()
 
@@ -130,5 +138,8 @@ class ResourcePatchContext internal constructor(
     @Suppress("unused")
     fun delete(name: String, packageName: String? = null) = resourceCoder.deleteFile(name, packageName)
 
-    override fun close() = resourceCoder.close()
+    override fun close() {
+        if (ResourceIds.current === resourceIds) ResourceIds.current = null
+        resourceCoder.close()
+    }
 }

--- a/src/main/kotlin/app/morphe/patcher/resource/CpuArchitecture.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/CpuArchitecture.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patcher
+ */
+
 package app.morphe.patcher.resource
 
 @Suppress("unused")

--- a/src/main/kotlin/app/morphe/patcher/resource/ResourceIds.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/ResourceIds.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patcher
+ */
+
 package app.morphe.patcher.resource
 
 import app.morphe.patcher.patch.PatchException

--- a/src/main/kotlin/app/morphe/patcher/resource/ResourceIds.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/ResourceIds.kt
@@ -1,0 +1,56 @@
+package app.morphe.patcher.resource
+
+import app.morphe.patcher.patch.PatchException
+
+/**
+ * The resource ids of the APK being patched, read from its resource table on first use.
+ *
+ * Available whether or not resources are decoded, so fingerprints of bytecode patches can refer to
+ * resource ids without depending on a resource patch. Ids are those of the input APK; resources a
+ * patch adds later are not included.
+ */
+class ResourceIds internal constructor(load: () -> Map<String, Long>) {
+    private val ids: Map<String, Long> by lazy(load)
+
+    /**
+     * @return The id of the resource, or `null` if the APK has no such resource.
+     */
+    fun getOrNull(type: ResourceType, name: String): Long? = ids[key(type, name)]
+
+    /**
+     * @return The id of the resource.
+     * @throws PatchException If the APK has no such resource.
+     */
+    operator fun get(type: ResourceType, name: String): Long =
+        getOrNull(type, name) ?: throw PatchException("Could not find resource type: $type name: $name")
+
+    /**
+     * @return Whether the APK has the resource.
+     */
+    fun has(type: ResourceType, name: String) = getOrNull(type, name) != null
+
+    internal companion object {
+        /** The ids of the APK currently being patched, for lookups that have no patch context at hand. */
+        @Volatile
+        internal var current: ResourceIds? = null
+
+        internal fun key(type: ResourceType, name: String) = "${type.value}/$name"
+    }
+}
+
+private fun current() = ResourceIds.current
+    ?: throw PatchException("Resource ids are only available while an APK is being patched")
+
+/**
+ * The id of a resource of the APK being patched.
+ *
+ * @throws PatchException If the APK has no such resource, or no APK is being patched.
+ */
+fun resourceId(type: ResourceType, name: String): Long = current()[type, name]
+
+/**
+ * Whether the APK being patched has the resource.
+ *
+ * @throws PatchException If no APK is being patched.
+ */
+fun hasResourceId(type: ResourceType, name: String): Boolean = current().has(type, name)

--- a/src/main/kotlin/app/morphe/patcher/resource/ResourceType.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/ResourceType.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patcher
+ */
+
 package app.morphe.patcher.resource
 
 /**

--- a/src/main/kotlin/app/morphe/patcher/resource/ResourceType.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/ResourceType.kt
@@ -1,0 +1,51 @@
+package app.morphe.patcher.resource
+
+/**
+ * The type of an Android resource, as it appears in the resource table and in `public.xml`.
+ *
+ * @param value The type name, e.g. `layout`.
+ */
+enum class ResourceType(val value: String) {
+    ANIM("anim"),
+    ANIMATOR("animator"),
+    ARRAY("array"),
+    ATTR("attr"),
+    BOOL("bool"),
+    COLOR("color"),
+    DIMEN("dimen"),
+    DRAWABLE("drawable"),
+    FONT("font"),
+    FRACTION("fraction"),
+    ID("id"),
+    INTEGER("integer"),
+    INTERPOLATOR("interpolator"),
+    LAYOUT("layout"),
+    MENU("menu"),
+    MIPMAP("mipmap"),
+    NAVIGATION("navigation"),
+    PLURALS("plurals"),
+    RAW("raw"),
+    STRING("string"),
+    STYLE("style"),
+    STYLEABLE("styleable"),
+    TRANSITION("transition"),
+    VALUES("values"),
+    XML("xml");
+
+    companion object {
+        private val VALUE_MAP: Map<String, ResourceType> = entries.associateBy { it.value }
+
+        /**
+         * @param value The type name, e.g. `layout`.
+         * @return The resource type, or `null` if the name is not a known type.
+         */
+        fun fromValueOrNull(value: String) = VALUE_MAP[value]
+
+        /**
+         * @param value The type name, e.g. `layout`.
+         * @throws IllegalArgumentException If the name is not a known type.
+         */
+        fun fromValue(value: String) = fromValueOrNull(value)
+            ?: throw IllegalArgumentException("Unknown resource type: $value")
+    }
+}

--- a/src/main/kotlin/app/morphe/patcher/resource/UncompressedFiles.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/UncompressedFiles.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-patcher
+ */
+
 package app.morphe.patcher.resource
 
 import com.reandroid.json.JSONObject

--- a/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
@@ -46,6 +46,8 @@ import java.nio.file.StandardCopyOption
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.attribute.FileTime
 import java.util.logging.Logger
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.measureTime
 
 /**
@@ -517,10 +519,16 @@ internal class ArsclibResourceCoder(
             val encoder = ApkModuleXmlEncoder()
             encoder.apkModule.use { loadedModule ->
                 loadedModule.setPreferredFramework(lazyPackageInfo.value.frameworkVersion)
+
+                fun Duration.roundToTenths(): Duration {
+                    val roundedMs = ((inWholeMilliseconds + 50) / 100) * 100
+                    return roundedMs.milliseconds
+                }
+
                 val scanDuration = measureTime {
                     encoder.scanDirectory(workingDir)
                     loadedModule.encodePatchedConfigurations(patchedConfigurations)
-                }
+                }.roundToTenths()
 
                 ApkModule.loadApkFile(apkFile).use { originalModule ->
                     val changedEntries = changedArchiveEntries(originalPackageName != newPackageName)
@@ -534,7 +542,7 @@ internal class ArsclibResourceCoder(
 
                     val writeDuration = measureTime {
                         loadedModule.writeApk(outputApk)
-                    }
+                    }.roundToTenths()
 
                     logger.info("Resource APK timings: scan=$scanDuration, write=$writeDuration")
                 }

--- a/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
@@ -948,7 +948,8 @@ internal class ArsclibResourceCoder(
     override fun resourceIds(): Map<String, Long> =
         ApkModule.loadApkFile(apkFile).use { module ->
             if (!module.hasTableBlock()) return@use emptyMap()
-            val ids = HashMap<String, Long>()
+
+            val ids = HashMap<String, Long>(1024, 0.5f)
             module.tableBlock.forEach { packageBlock ->
                 packageBlock.listSpecTypePairs().forEach { specTypePair ->
                     specTypePair.forEach { typeBlock ->

--- a/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/coder/ArsclibResourceCoder.kt
@@ -937,6 +937,26 @@ internal class ArsclibResourceCoder(
         return retval
     }
 
+    override fun resourceIds(): Map<String, Long> =
+        ApkModule.loadApkFile(apkFile).use { module ->
+            if (!module.hasTableBlock()) return@use emptyMap()
+            val ids = HashMap<String, Long>()
+            module.tableBlock.forEach { packageBlock ->
+                packageBlock.listSpecTypePairs().forEach { specTypePair ->
+                    specTypePair.forEach { typeBlock ->
+                        typeBlock.listEntries(true).forEach { entry ->
+                            // Unsigned: ids are 0x7fxxxxxx for the app, so this is a plain Long.
+                            ids.putIfAbsent(
+                                "${typeBlock.typeName}/${entry.name}",
+                                entry.resourceId.toLong() and 0xffffffffL,
+                            )
+                        }
+                    }
+                }
+            }
+            ids
+        }
+
     override fun listApkEntries(prefix: String): List<String> =
         ZFile.openReadOnly(apkFile).use { zFile ->
             zFile.entries().mapNotNull { entry ->

--- a/src/main/kotlin/app/morphe/patcher/resource/coder/ResourceCoder.kt
+++ b/src/main/kotlin/app/morphe/patcher/resource/coder/ResourceCoder.kt
@@ -36,6 +36,11 @@ internal interface ResourceCoder : Closeable {
     fun listApkEntries(prefix: String = ""): List<String>
 
     /**
+     * The resource ids of the input APK, keyed by `type/name`, read from its resource table.
+     */
+    fun resourceIds(): Map<String, Long>
+
+    /**
      * Decode raw resources from the APK into the working directory and update the package metadata.
      *
      * @return The package's metadata.

--- a/src/main/kotlin/app/morphe/patcher/util/PatchClasses.kt
+++ b/src/main/kotlin/app/morphe/patcher/util/PatchClasses.kt
@@ -57,9 +57,9 @@ internal class PatchClasses internal constructor(
     }
 
     private data class ClassIndexValues(
-        val strings: MutableSet<String> = HashSet(),
-        val referencedTypeHashes: MutableSet<Int> = HashSet(),
-        val literalValues: MutableSet<Long> = HashSet(),
+        val strings: MutableSet<String> = HashSet(1024, 0.5f),
+        val referencedTypeHashes: MutableSet<Int> = HashSet(1024, 0.5f),
+        val literalValues: MutableSet<Long> = HashSet(1024, 0.5f),
     )
 
     /** Collect string, type-reference, and literal values in one traversal. */

--- a/src/test/kotlin/app/morphe/patcher/resource/ResourceIdsTest.kt
+++ b/src/test/kotlin/app/morphe/patcher/resource/ResourceIdsTest.kt
@@ -1,0 +1,99 @@
+package app.morphe.patcher.resource
+
+import app.morphe.patcher.patch.PatchException
+import app.morphe.patcher.resource.coder.ArsclibResourceCoder
+import app.morphe.patcher.resourceLiteral
+import com.android.tools.build.apkzlib.zip.ZFile
+import com.reandroid.arsc.chunk.TableBlock
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
+import java.io.ByteArrayInputStream
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+internal class ResourceIdsTest {
+    @AfterEach
+    fun clearCurrent() {
+        ResourceIds.current = null
+    }
+
+    private fun apkWithTable(tempDir: File): File {
+        val table = TableBlock()
+        val pkg = table.newPackage(0x7f, "com.test.app")
+        pkg.getOrCreate("", "id", "spinner").setValueAsBoolean(false)
+        pkg.getOrCreate("", "layout", "account_compact_link").setValueAsBoolean(false)
+        pkg.getOrCreate("", "string", "app_name").setValueAsString("Test")
+        table.refresh()
+        val apk = tempDir.resolve("input.apk")
+        ZFile.openReadWrite(apk).use { zip ->
+            zip.add("resources.arsc", ByteArrayInputStream(table.bytes))
+        }
+        return apk
+    }
+
+    @Test
+    fun `resource ids are read from the resource table`(@TempDir tempDir: File) {
+        val coder = ArsclibResourceCoder(tempDir.resolve("working").apply { mkdirs() }, apkWithTable(tempDir))
+
+        val ids = ResourceIds { coder.resourceIds() }
+
+        assertEquals(0x7f000000L, ids[ResourceType.ID, "spinner"] and 0xff000000L)
+        assertTrue(ids.has(ResourceType.LAYOUT, "account_compact_link"))
+        assertTrue(ids.has(ResourceType.STRING, "app_name"))
+        assertNull(ids.getOrNull(ResourceType.ID, "missing"))
+        assertThrows<PatchException> { ids[ResourceType.ID, "missing"] }
+        assertTrue(ids[ResourceType.ID, "spinner"] != ids[ResourceType.LAYOUT, "account_compact_link"])
+    }
+
+    @Test
+    fun `an APK without a resource table has no ids`(@TempDir tempDir: File) {
+        val apk = tempDir.resolve("input.apk").also { ZFile.openReadWrite(it).use { } }
+        val coder = ArsclibResourceCoder(tempDir.resolve("working").apply { mkdirs() }, apk)
+
+        assertFalse(ResourceIds { coder.resourceIds() }.has(ResourceType.ID, "spinner"))
+    }
+
+    @Test
+    fun `resourceLiteral resolves the id lazily through the current APK`(@TempDir tempDir: File) {
+        val coder = ArsclibResourceCoder(tempDir.resolve("working").apply { mkdirs() }, apkWithTable(tempDir))
+        val ids = ResourceIds { coder.resourceIds() }
+        val filter = resourceLiteral(ResourceType.ID, "spinner")
+        val optional = resourceLiteral(ResourceType.ID, "missing", exceptionIfResourceNotFound = false)
+        val required = resourceLiteral(ResourceType.ID, "missing")
+
+        ResourceIds.current = ids
+
+        assertEquals(ids[ResourceType.ID, "spinner"], filter.literalValue)
+        assertNull(optional.literalValue)
+        assertThrows<PatchException> { required.literalValue }
+    }
+
+    @Test
+    fun `resource id lookups fail clearly outside of patching`() {
+        assertThrows<PatchException> { resourceId(ResourceType.ID, "spinner") }
+        assertThrows<PatchException> { hasResourceId(ResourceType.ID, "spinner") }
+    }
+
+    @Test
+    fun `resource types map from their names`() {
+        assertEquals(ResourceType.LAYOUT, ResourceType.fromValue("layout"))
+        assertNull(ResourceType.fromValueOrNull("nope"))
+        assertThrows<IllegalArgumentException> { ResourceType.fromValue("nope") }
+    }
+
+    @Test
+    fun `real APK table when available`(@TempDir tempDir: File) {
+        val apk = System.getenv("MORPHE_TEST_APK")?.let(::File)?.takeIf { it.isFile } ?: return
+        val coder = ArsclibResourceCoder(tempDir.resolve("working").apply { mkdirs() }, apk)
+
+        val ids = ResourceIds { coder.resourceIds() }
+
+        assertTrue(ids.has(ResourceType.ID, "spinner"))
+        assertTrue(ids.has(ResourceType.LAYOUT, "account_compact_link"))
+    }
+}


### PR DESCRIPTION
Closes #200.

Resource ids of the APK being patched are now read by the patcher itself, from the resource table, on first use. That makes them available whether or not resources are decoded, so fingerprints of bytecode patches can refer to resource ids without depending on a resource patch (the discovery-driven index sketched in #170 can rely on that too).

- `ResourceType` enum, and a `ResourceIds` lookup exposed as `ResourcePatchContext.resourceIds` plus `resourceId(type, name)` / `hasResourceId(type, name)` for code without a context at hand.
- `resourceLiteral(type, name, exceptionIfResourceNotFound = true, opcodes, location)` returns a plain `LiteralFilter`, so the literal index from #170 covers it. The patches-library `ResourceLiteralFilter` is a custom `OpcodesFilter` subclass the index cannot see, which left every resource-id fingerprint on a full class scan (113 in the YouTube/shared patches; about 13 s of a phone patch in my measurements).
- `literal { }` accepts a nullable lambda; a null literal never matches and produces an empty candidate set.

Ids are those of the input APK, as with the library's `public.xml`-based map. Docs added to `2_2_1_fingerprinting.md`.

Follow-up in morphe-patches-library once released: `ResourceType` becomes a typealias, `resourceLiteral`/`getResourceId`/`hasResourceId` delegate to the patcher, and `resourceMappingPatch` becomes a no-op kept for dependency compatibility.
